### PR TITLE
修复继承类中无法设置isOpenInterestRect属性的问题

### DIFF
--- a/Source/LBXScanViewController.swift
+++ b/Source/LBXScanViewController.swift
@@ -42,7 +42,7 @@ public class LBXScanViewController: UIViewController, UIImagePickerControllerDel
     {
         isNeedCodeImage = needCodeImg;
     }
-    
+    //设置框内识别
     public func setOpenInterestRect(isOpen:Bool){
         isOpenInterestRect = isOpen
     }

--- a/Source/LBXScanViewController.swift
+++ b/Source/LBXScanViewController.swift
@@ -42,6 +42,10 @@ public class LBXScanViewController: UIViewController, UIImagePickerControllerDel
     {
         isNeedCodeImage = needCodeImg;
     }
+    
+    public func setOpenInterestRect(isOpen:Bool){
+        isOpenInterestRect = isOpen
+    }
  
     override public func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)


### PR DESCRIPTION
`//设置框内识别
    public func setOpenInterestRect(isOpen:Bool){
        isOpenInterestRect = isOpen
    }`
参考LBXScanViewController类，并在其实新添加了设置isOpenInterestRect的方法，经过测试可用。