### PR TITLE
解决LBXScanViewController内存泄漏问题

### DIFF
--- a/Source/LBXScanViewController.swift
+++ b/Source/LBXScanViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Foundation
 import AVFoundation
 
-public protocol LBXScanViewControllerDelegate {
+public protocol LBXScanViewControllerDelegate: class {
      func scanFinished(scanResult: LBXScanResult, error: String?)
 }
 
@@ -18,7 +18,7 @@ public protocol LBXScanViewControllerDelegate {
 open class LBXScanViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
  //返回扫码结果，也可以通过继承本控制器，改写该handleCodeResult方法即可
-   open var scanResultDelegate: LBXScanViewControllerDelegate?
+   open weak var scanResultDelegate: LBXScanViewControllerDelegate?
     
    open var scanObj: LBXScanWrapper?
     
@@ -209,7 +209,7 @@ open class LBXScanViewController: UIViewController, UIImagePickerControllerDeleg
 //                    strongSelf.startScan()
 //                }
             }
-            
+        
             alertController.addAction(alertAction)
             present(alertController, animated: true, completion: nil)
     }


### PR DESCRIPTION
因为scanResultDelegate属性没有声明称weak的，所以如果设置了scanResultDelegate就会循环引用造成内存泄漏。