### PR TITLE
修改错误处理方式

### DIFF
--- a/Source/LBXPermissions.swift
+++ b/Source/LBXPermissions.swift
@@ -11,18 +11,15 @@ import AVFoundation
 import Photos
 import AssetsLibrary
 
-
-
 class LBXPermissions: NSObject {
 
-    //MARK: ----获取相册权限
-    static func authorizePhotoWith(comletion:@escaping (Bool)->Void )
-    {
+    // MARK: - ---获取相册权限
+    static func authorizePhotoWith(comletion:@escaping (Bool) -> Void) {
         let granted = PHPhotoLibrary.authorizationStatus()
         switch granted {
         case PHAuthorizationStatus.authorized:
             comletion(true)
-        case PHAuthorizationStatus.denied,PHAuthorizationStatus.restricted:
+        case PHAuthorizationStatus.denied, PHAuthorizationStatus.restricted:
             comletion(false)
         case PHAuthorizationStatus.notDetermined:
             PHPhotoLibrary.requestAuthorization({ (status) in
@@ -32,45 +29,41 @@ class LBXPermissions: NSObject {
             })
         }
     }
-    
-    //MARK: ---相机权限
-    static func authorizeCameraWith(comletion:@escaping (Bool)->Void )
-    {
-        let granted = AVCaptureDevice.authorizationStatus(for: AVMediaType.video);
-        
+
+    // MARK: - --相机权限
+    static func authorizeCameraWith(comletion:@escaping (Bool) -> Void ) {
+        let granted = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
+
         switch granted {
         case .authorized:
             comletion(true)
-            break;
+            break
         case .denied:
             comletion(false)
-            break;
+            break
         case .restricted:
             comletion(false)
-            break;
+            break
         case .notDetermined:
-            AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: { (granted:Bool) in
+            AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: { (granted: Bool) in
                 DispatchQueue.main.async {
                     comletion(granted)
                 }
             })
         }
     }
-    
-    //MARK:跳转到APP系统设置权限界面
-    static func jumpToSystemPrivacySetting()
-    {
-        let appSetting = URL(string:UIApplicationOpenSettingsURLString)
-        
-        if appSetting != nil
-        {
+
+    // MARK: 跳转到APP系统设置权限界面
+    static func jumpToSystemPrivacySetting() {
+        let appSetting = URL(string: UIApplicationOpenSettingsURLString)
+
+        if appSetting != nil {
             if #available(iOS 10, *) {
                 UIApplication.shared.open(appSetting!, options: [:], completionHandler: nil)
-            }
-            else{
+            } else {
                 UIApplication.shared.openURL(appSetting!)
             }
         }
     }
-    
+
 }

--- a/Source/LBXScanLineAnimation.swift
+++ b/Source/LBXScanLineAnimation.swift
@@ -12,78 +12,66 @@ class LBXScanLineAnimation: UIImageView {
 
     var isAnimationing = false
     var animationRect: CGRect = CGRect.zero
-    
-    func startAnimatingWithRect(animationRect: CGRect, parentView: UIView, image: UIImage?)
-    { 
+
+    func startAnimatingWithRect(animationRect: CGRect, parentView: UIView, image: UIImage?) {
         self.image = image
         self.animationRect = animationRect
         parentView.addSubview(self)
-        
-        self.isHidden = false;
-        
-        isAnimationing = true;
-        
-        if image != nil
-        {
+
+        self.isHidden = false
+
+        isAnimationing = true
+
+        if image != nil {
             stepAnimation()
         }
-        
+
     }
-    
-    @objc func stepAnimation()
-    {
+
+    @objc func stepAnimation() {
         if (!isAnimationing) {
-            return;
+            return
         }
-        
-        var frame:CGRect = animationRect;
-        
-        let hImg = self.image!.size.height * animationRect.size.width / self.image!.size.width;
-        
-        frame.origin.y -= hImg;
-        frame.size.height = hImg;
-        self.frame = frame;
-        self.alpha = 0.0;
-        
+
+        var frame: CGRect = animationRect
+
+        let hImg = self.image!.size.height * animationRect.size.width / self.image!.size.width
+
+        frame.origin.y -= hImg
+        frame.size.height = hImg
+        self.frame = frame
+        self.alpha = 0.0
+
         UIView.animate(withDuration: 1.4, animations: { () -> Void in
-            
-            self.alpha = 1.0;
-            
-            var frame = self.animationRect;
-            let hImg = self.image!.size.height * self.animationRect.size.width / self.image!.size.width;
-            
-            frame.origin.y += (frame.size.height -  hImg);
-            frame.size.height = hImg;
-            
-            self.frame = frame;
-            
-            }, completion:{ (value: Bool) -> Void in
-                                
-                self.perform(#selector(LBXScanLineAnimation.stepAnimation), with: nil, afterDelay: 0.3)
+
+            self.alpha = 1.0
+
+            var frame = self.animationRect
+            let hImg = self.image!.size.height * self.animationRect.size.width / self.image!.size.width
+
+            frame.origin.y += (frame.size.height -  hImg)
+            frame.size.height = hImg
+
+            self.frame = frame
+
+        }, completion: { (value: Bool) -> Void in
+
+            self.perform(#selector(LBXScanLineAnimation.stepAnimation), with: nil, afterDelay: 0.3)
         })
-        
+
     }
-    
-    func stopStepAnimating()
-    {
-        self.isHidden = true;
-        isAnimationing = false;
+
+    func stopStepAnimating() {
+        self.isHidden = true
+        isAnimationing = false
     }
-    
-    static public func instance()->LBXScanLineAnimation
-    {
+
+    static public func instance() -> LBXScanLineAnimation {
         return LBXScanLineAnimation()
     }
-    
-    deinit
-    {
-//        print("LBXScanLineAnimation deinit")
+
+    deinit {
         stopStepAnimating()
     }
 
 }
-
-
-
-
-

--- a/Source/LBXScanNetAnimation.swift
+++ b/Source/LBXScanNetAnimation.swift
@@ -11,75 +11,62 @@ import UIKit
 class LBXScanNetAnimation: UIImageView {
 
     var isAnimationing = false
-    var animationRect:CGRect = CGRect.zero
+    var animationRect: CGRect = CGRect.zero
 
-    
-    
-    static public func instance()->LBXScanNetAnimation
-    {
+    static public func instance() -> LBXScanNetAnimation {
         return LBXScanNetAnimation()
     }
-    
-    func startAnimatingWithRect(animationRect:CGRect, parentView:UIView, image:UIImage?)
-    {
+
+    func startAnimatingWithRect(animationRect: CGRect, parentView: UIView, image: UIImage?) {
         self.image = image
         self.animationRect = animationRect
         parentView.addSubview(self)
-        
-        self.isHidden = false;
-        
-        isAnimationing = true;
-        
-        if (image != nil)
-        {
-           stepAnimation()
+
+        self.isHidden = false
+
+        isAnimationing = true
+
+        if (image != nil) {
+            stepAnimation()
         }
-       
-       
-        
+
     }
-    
-    @objc func stepAnimation()
-    {
+
+    @objc func stepAnimation() {
         if (!isAnimationing) {
-            return;
+            return
         }
-        
-        var frame = animationRect;
-        
-        
-        let hImg = self.image!.size.height * animationRect.size.width / self.image!.size.width;
-        
-        frame.origin.y -= hImg;
-        frame.size.height = hImg;
-        self.frame = frame;
-        
-        self.alpha = 0.0;
-        
+        var frame = animationRect
+        let hImg = self.image!.size.height * animationRect.size.width / self.image!.size.width
+
+        frame.origin.y -= hImg
+        frame.size.height = hImg
+        self.frame = frame
+
+        self.alpha = 0.0
+
         UIView.animate(withDuration: 1.2, animations: { () -> Void in
-            
-            self.alpha = 1.0;
-            
-            var frame = self.animationRect;
-            let hImg = self.image!.size.height * self.animationRect.size.width / self.image!.size.width;
-            
-            frame.origin.y += (frame.size.height -  hImg);
-            frame.size.height = hImg;
-            
-            self.frame = frame;
-            
-            }, completion:{ (value: Bool) -> Void in
-                
-                self.perform(#selector(LBXScanNetAnimation.stepAnimation), with: nil, afterDelay: 0.3)
-               
+
+            self.alpha = 1.0
+
+            var frame = self.animationRect
+            let hImg = self.image!.size.height * self.animationRect.size.width / self.image!.size.width
+
+            frame.origin.y += (frame.size.height -  hImg)
+            frame.size.height = hImg
+
+            self.frame = frame
+
+        }, completion: { (value: Bool) -> Void in
+
+            self.perform(#selector(LBXScanNetAnimation.stepAnimation), with: nil, afterDelay: 0.3)
+
         })
-        
     }
-    
-    func stopStepAnimating()
-    {
-        self.isHidden = true;
-        isAnimationing = false;
+
+    func stopStepAnimating() {
+        self.isHidden = true
+        isAnimationing = false
     }
 
 }

--- a/Source/LBXScanView.swift
+++ b/Source/LBXScanView.swift
@@ -8,45 +8,42 @@
 
 import UIKit
 
-open class LBXScanView: UIView
-{
+open class LBXScanView: UIView {
     //扫码区域各种参数
-    var viewStyle:LBXScanViewStyle = LBXScanViewStyle()
-    
-     //扫码区域
-    var scanRetangleRect:CGRect = CGRect.zero
-    
+    var viewStyle: LBXScanViewStyle = LBXScanViewStyle()
+
+    //扫码区域
+    var scanRetangleRect: CGRect = CGRect.zero
+
     //线条扫码动画封装
-    var scanLineAnimation:LBXScanLineAnimation?
-    
+    var scanLineAnimation: LBXScanLineAnimation?
+
     //网格扫码动画封装
-    var scanNetAnimation:LBXScanNetAnimation?
-    
+    var scanNetAnimation: LBXScanNetAnimation?
+
     //线条在中间位置，不移动
-    var scanLineStill:UIImageView?
-    
+    var scanLineStill: UIImageView?
+
     //启动相机时 菊花等待
-    var activityView:UIActivityIndicatorView?
-    
+    var activityView: UIActivityIndicatorView?
+
     //启动相机中的提示文字
-    var labelReadying:UILabel?
-    
+    var labelReadying: UILabel?
+
     //记录动画状态
-    var isAnimationing:Bool = false
-    
+    var isAnimationing: Bool = false
+
     /**
-    初始化扫描界面
-    - parameter frame:  界面大小，一般为视频显示区域
-    - parameter vstyle: 界面效果参数
-    
-    - returns: instancetype
-    */
-    public init(frame:CGRect, vstyle:LBXScanViewStyle )
-    {
+     初始化扫描界面
+     - parameter frame:  界面大小，一般为视频显示区域
+     - parameter vstyle: 界面效果参数
+     
+     - returns: instancetype
+     */
+    public init(frame: CGRect, vstyle: LBXScanViewStyle ) {
         viewStyle = vstyle
-        
-        switch (viewStyle.anmiationStyle)
-        {
+
+        switch (viewStyle.anmiationStyle) {
         case LBXScanViewAnimationStyle.LineMove:
             scanLineAnimation = LBXScanLineAnimation.instance()
             break
@@ -57,253 +54,228 @@ open class LBXScanView: UIView
             scanLineStill = UIImageView()
             scanLineStill?.image = viewStyle.animationImage
             break
-            
-            
+
         default:
             break
         }
-        
-        var frameTmp = frame;
+
+        var frameTmp = frame
         frameTmp.origin = CGPoint.zero
-        
+
         super.init(frame: frameTmp)
-        
+
         backgroundColor = UIColor.clear
     }
-    
+
     override init(frame: CGRect) {
-        
-        var frameTmp = frame;
+
+        var frameTmp = frame
         frameTmp.origin = CGPoint.zero
-        
+
         super.init(frame: frameTmp)
-        
+
         backgroundColor = UIColor.clear
     }
-    
-    required public init?(coder aDecoder: NSCoder)
-    {
+
+    required public init?(coder aDecoder: NSCoder) {
         self.init()
-       
+
     }
-    
-    deinit
-    {
-        if (scanLineAnimation != nil)
-        {
+
+    deinit {
+        if (scanLineAnimation != nil) {
             scanLineAnimation!.stopStepAnimating()
         }
-        if (scanNetAnimation != nil)
-        {
+        if (scanNetAnimation != nil) {
             scanNetAnimation!.stopStepAnimating()
         }
-        
-        
-//        print("LBXScanView deinit")
+
+        //        print("LBXScanView deinit")
     }
-    
-    
-    /**
-    *  开始扫描动画
-    */
-    func startScanAnimation()
-    {
-        if isAnimationing
-        {
-            return
-        }
-        
-        isAnimationing = true
-        
-        let cropRect:CGRect = getScanRectForAnimation()
-        
-        switch viewStyle.anmiationStyle
-        {
-        case LBXScanViewAnimationStyle.LineMove:
-            
-//            print(NSStringFromCGRect(cropRect))
-            
-            scanLineAnimation!.startAnimatingWithRect(animationRect: cropRect, parentView: self, image:viewStyle.animationImage )
-            break
-        case LBXScanViewAnimationStyle.NetGrid:
-            
-            scanNetAnimation!.startAnimatingWithRect(animationRect: cropRect, parentView: self, image:viewStyle.animationImage )
-            break
-        case LBXScanViewAnimationStyle.LineStill:
-            
-            let stillRect = CGRect(x: cropRect.origin.x+20,
-                                   y: cropRect.origin.y + cropRect.size.height/2,
-                                   width: cropRect.size.width-40,
-                                   height: 2);
-            self.scanLineStill?.frame = stillRect
-            
-            self.addSubview(scanLineStill!)
-            self.scanLineStill?.isHidden = false
-            
-            break
-            
-        default: break
-            
-        }
-    }
-    
+
     /**
      *  开始扫描动画
      */
-    func stopScanAnimation()
-    {
-        isAnimationing = false
-        
-        switch viewStyle.anmiationStyle
-        {
+    func startScanAnimation() {
+        if isAnimationing {
+            return
+        }
+
+        isAnimationing = true
+
+        let cropRect: CGRect = getScanRectForAnimation()
+
+        switch viewStyle.anmiationStyle {
         case LBXScanViewAnimationStyle.LineMove:
-            
-            scanLineAnimation?.stopStepAnimating()
+
+            //            print(NSStringFromCGRect(cropRect))
+
+            scanLineAnimation!.startAnimatingWithRect(animationRect: cropRect, parentView: self, image: viewStyle.animationImage )
             break
         case LBXScanViewAnimationStyle.NetGrid:
-            
-            scanNetAnimation?.stopStepAnimating()
+
+            scanNetAnimation!.startAnimatingWithRect(animationRect: cropRect, parentView: self, image: viewStyle.animationImage )
             break
         case LBXScanViewAnimationStyle.LineStill:
-             self.scanLineStill?.isHidden = true
-            
+
+            let stillRect = CGRect(x: cropRect.origin.x+20,
+                                   y: cropRect.origin.y + cropRect.size.height/2,
+                                   width: cropRect.size.width-40,
+                                   height: 2)
+            self.scanLineStill?.frame = stillRect
+
+            self.addSubview(scanLineStill!)
+            self.scanLineStill?.isHidden = false
+
             break
-            
+
         default: break
-            
+
         }
     }
 
-    
-    
+    /**
+     *  开始扫描动画
+     */
+    func stopScanAnimation() {
+        isAnimationing = false
+
+        switch viewStyle.anmiationStyle {
+        case LBXScanViewAnimationStyle.LineMove:
+
+            scanLineAnimation?.stopStepAnimating()
+            break
+        case LBXScanViewAnimationStyle.NetGrid:
+
+            scanNetAnimation?.stopStepAnimating()
+            break
+        case LBXScanViewAnimationStyle.LineStill:
+            self.scanLineStill?.isHidden = true
+
+            break
+
+        default: break
+
+        }
+    }
+
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.
-    override open func draw(_ rect: CGRect)
-    {
+    override open func draw(_ rect: CGRect) {
         // Drawing code
         drawScanRect()
     }
-    
-    //MARK:----- 绘制扫码效果-----
-    func drawScanRect()
-    {
+
+    // MARK: - ---- 绘制扫码效果-----
+    func drawScanRect() {
         let XRetangleLeft = viewStyle.xScanRetangleOffset
         var sizeRetangle = CGSize(width: self.frame.size.width - XRetangleLeft*2.0, height: self.frame.size.width - XRetangleLeft*2.0)
-        if viewStyle.whRatio != 1.0
-        {
-            let w = sizeRetangle.width;
-            var h:CGFloat = w / viewStyle.whRatio
-            
-            let hInt:Int = Int(h)
+        if viewStyle.whRatio != 1.0 {
+            let w = sizeRetangle.width
+            var h: CGFloat = w / viewStyle.whRatio
+
+            let hInt: Int = Int(h)
             h = CGFloat(hInt)
-            
+
             sizeRetangle = CGSize(width: w, height: h)
         }
-        
+
         //扫码区域Y轴最小坐标
         let YMinRetangle = self.frame.size.height / 2.0 - sizeRetangle.height/2.0 - viewStyle.centerUpOffset
         let YMaxRetangle = YMinRetangle + sizeRetangle.height
         let XRetangleRight = self.frame.size.width - XRetangleLeft
-        
-        
-//        print("frame:%@",NSStringFromCGRect(self.frame))
-        
+
+        //        print("frame:%@",NSStringFromCGRect(self.frame))
+
         let context = UIGraphicsGetCurrentContext()!
-        
-        
+
         //非扫码区域半透明
-            //设置非识别区域颜色
+        //设置非识别区域颜色
         context.setFillColor(viewStyle.color_NotRecoginitonArea.cgColor)
-            //填充矩形
-            //扫码区域上面填充
+        //填充矩形
+        //扫码区域上面填充
         var rect = CGRect(x: 0, y: 0, width: self.frame.size.width, height: YMinRetangle)
-            context.fill(rect)
-            
-            
-            //扫码区域左边填充
+        context.fill(rect)
+
+        //扫码区域左边填充
         rect = CGRect(x: 0, y: YMinRetangle, width: XRetangleLeft, height: sizeRetangle.height)
-            context.fill(rect)
-            
-            //扫码区域右边填充
-        rect = CGRect(x: XRetangleRight, y: YMinRetangle, width: XRetangleLeft,height: sizeRetangle.height)
-            context.fill(rect)
-            
-            //扫码区域下面填充
-        rect = CGRect(x: 0, y: YMaxRetangle, width: self.frame.size.width,height: self.frame.size.height - YMaxRetangle)
-            context.fill(rect)
-            //执行绘画
-            context.strokePath()
-        
-        
-        if viewStyle.isNeedShowRetangle
-        {
+        context.fill(rect)
+
+        //扫码区域右边填充
+        rect = CGRect(x: XRetangleRight, y: YMinRetangle, width: XRetangleLeft, height: sizeRetangle.height)
+        context.fill(rect)
+
+        //扫码区域下面填充
+        rect = CGRect(x: 0, y: YMaxRetangle, width: self.frame.size.width, height: self.frame.size.height - YMaxRetangle)
+        context.fill(rect)
+        //执行绘画
+        context.strokePath()
+
+        if viewStyle.isNeedShowRetangle {
             //中间画矩形(正方形)
             context.setStrokeColor(viewStyle.colorRetangleLine.cgColor)
-            context.setLineWidth(1);
-            
+            context.setLineWidth(1)
+
             context.addRect(CGRect(x: XRetangleLeft, y: YMinRetangle, width: sizeRetangle.width, height: sizeRetangle.height))
-            
+
             //CGContextMoveToPoint(context, XRetangleLeft, YMinRetangle);
             //CGContextAddLineToPoint(context, XRetangleLeft+sizeRetangle.width, YMinRetangle);
-            
+
             context.strokePath()
-            
+
         }
-        scanRetangleRect = CGRect(x: XRetangleLeft, y:  YMinRetangle, width: sizeRetangle.width, height: sizeRetangle.height)
-        
-        
+        scanRetangleRect = CGRect(x: XRetangleLeft, y: YMinRetangle, width: sizeRetangle.width, height: sizeRetangle.height)
+
         //画矩形框4格外围相框角
-        
+
         //相框角的宽度和高度
-        let wAngle = viewStyle.photoframeAngleW;
-        let hAngle = viewStyle.photoframeAngleH;
-        
+        let wAngle = viewStyle.photoframeAngleW
+        let hAngle = viewStyle.photoframeAngleH
+
         //4个角的 线的宽度
         let linewidthAngle = viewStyle.photoframeLineW;// 经验参数：6和4
-        
+
         //画扫码矩形以及周边半透明黑色坐标参数
-        var diffAngle = linewidthAngle/3;
+        var diffAngle = linewidthAngle/3
         diffAngle = linewidthAngle / 2; //框外面4个角，与框有缝隙
         diffAngle = linewidthAngle/2;  //框4个角 在线上加4个角效果
         diffAngle = 0;//与矩形框重合
-        
-        switch viewStyle.photoframeAngleStyle
-        {
+
+        switch viewStyle.photoframeAngleStyle {
         case LBXScanViewPhotoframeAngleStyle.Outer:
-                diffAngle = linewidthAngle/3//框外面4个角，与框紧密联系在一起
-           
+            diffAngle = linewidthAngle/3//框外面4个角，与框紧密联系在一起
+
         case LBXScanViewPhotoframeAngleStyle.On:
-                diffAngle = 0
-            
+            diffAngle = 0
+
         case LBXScanViewPhotoframeAngleStyle.Inner:
-                diffAngle = -viewStyle.photoframeLineW/2
+            diffAngle = -viewStyle.photoframeLineW/2
         }
-        
-        context.setStrokeColor(viewStyle.colorAngle.cgColor);
-        context.setFillColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0);
-        
+
+        context.setStrokeColor(viewStyle.colorAngle.cgColor)
+        context.setFillColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+
         // Draw them with a 2.0 stroke width so they are a bit more visible.
-        context.setLineWidth(linewidthAngle);
-        
-        
+        context.setLineWidth(linewidthAngle)
+
         //
         let leftX = XRetangleLeft - diffAngle
         let topY = YMinRetangle - diffAngle
         let rightX = XRetangleRight + diffAngle
         let bottomY = YMaxRetangle + diffAngle
-        
+
         //左上角水平线
         context.move(to: CGPoint(x: leftX-linewidthAngle/2, y: topY))
         context.addLine(to: CGPoint(x: leftX + wAngle, y: topY))
-        
+
         //左上角垂直线
         context.move(to: CGPoint(x: leftX, y: topY-linewidthAngle/2))
         context.addLine(to: CGPoint(x: leftX, y: topY+hAngle))
-        
+
         //左下角水平线
         context.move(to: CGPoint(x: leftX-linewidthAngle/2, y: bottomY))
         context.addLine(to: CGPoint(x: leftX + wAngle, y: bottomY))
-        
+
         //左下角垂直线
         context.move(to: CGPoint(x: leftX, y: bottomY+linewidthAngle/2))
         context.addLine(to: CGPoint(x: leftX, y: bottomY - hAngle))
@@ -311,90 +283,83 @@ open class LBXScanView: UIView
         //右上角水平线
         context.move(to: CGPoint(x: rightX+linewidthAngle/2, y: topY))
         context.addLine(to: CGPoint(x: rightX - wAngle, y: topY))
-        
+
         //右上角垂直线
         context.move(to: CGPoint(x: rightX, y: topY-linewidthAngle/2))
         context.addLine(to: CGPoint(x: rightX, y: topY + hAngle))
 
-//        右下角水平线
+        //右下角水平线
         context.move(to: CGPoint(x: rightX+linewidthAngle/2, y: bottomY))
         context.addLine(to: CGPoint(x: rightX - wAngle, y: bottomY))
-        
+
         //右下角垂直线
         context.move(to: CGPoint(x: rightX, y: bottomY+linewidthAngle/2))
         context.addLine(to: CGPoint(x: rightX, y: bottomY - hAngle))
-        
+
         context.strokePath()
     }
-    
-    func getScanRectForAnimation() -> CGRect
-    {
+
+    func getScanRectForAnimation() -> CGRect {
         let XRetangleLeft = viewStyle.xScanRetangleOffset
         var sizeRetangle = CGSize(width: self.frame.size.width - XRetangleLeft*2, height: self.frame.size.width - XRetangleLeft*2)
-        
-        if viewStyle.whRatio != 1
-        {
+
+        if viewStyle.whRatio != 1 {
             let w = sizeRetangle.width
             var h = w / viewStyle.whRatio
-            
-            
-            let hInt:Int = Int(h)
+
+            let hInt: Int = Int(h)
             h = CGFloat(hInt)
-            
+
             sizeRetangle = CGSize(width: w, height: h)
         }
-        
+
         //扫码区域Y轴最小坐标
         let YMinRetangle = self.frame.size.height / 2.0 - sizeRetangle.height/2.0 - viewStyle.centerUpOffset
         //扫码区域坐标
         let cropRect =  CGRect(x: XRetangleLeft, y: YMinRetangle, width: sizeRetangle.width, height: sizeRetangle.height)
-        
-        return cropRect;
+
+        return cropRect
     }
 
     //根据矩形区域，获取识别区域
-    static func getScanRectWithPreView(preView:UIView, style:LBXScanViewStyle) -> CGRect
-    {
-        let XRetangleLeft = style.xScanRetangleOffset;
+    static func getScanRectWithPreView(preView: UIView, style: LBXScanViewStyle) -> CGRect {
+        let XRetangleLeft = style.xScanRetangleOffset
         var sizeRetangle = CGSize(width: preView.frame.size.width - XRetangleLeft*2, height: preView.frame.size.width - XRetangleLeft*2)
-        
-        if style.whRatio != 1
-        {
+
+        if style.whRatio != 1 {
             let w = sizeRetangle.width
             var h = w / style.whRatio
-            
-            let hInt:Int = Int(h)
+
+            let hInt: Int = Int(h)
             h = CGFloat(hInt)
-            
+
             sizeRetangle = CGSize(width: w, height: h)
         }
-        
+
         //扫码区域Y轴最小坐标
         let YMinRetangle = preView.frame.size.height / 2.0 - sizeRetangle.height/2.0 - style.centerUpOffset
         //扫码区域坐标
         let cropRect =  CGRect(x: XRetangleLeft, y: YMinRetangle, width: sizeRetangle.width, height: sizeRetangle.height)
-        
-        
+
         //计算兴趣区域
-        var rectOfInterest:CGRect
-        
+        var rectOfInterest: CGRect
+
         //ref:http://www.cocoachina.com/ios/20141225/10763.html
-        let size = preView.bounds.size;
-        let p1 = size.height/size.width;
-        
-        let p2:CGFloat = 1920.0/1080.0 //使用了1080p的图像输出
+        let size = preView.bounds.size
+        let p1 = size.height/size.width
+
+        let p2: CGFloat = 1920.0/1080.0 //使用了1080p的图像输出
         if p1 < p2 {
-            let fixHeight = size.width * 1920.0 / 1080.0;
-            let fixPadding = (fixHeight - size.height)/2;
+            let fixHeight = size.width * 1920.0 / 1080.0
+            let fixPadding = (fixHeight - size.height)/2
             rectOfInterest = CGRect(x: (cropRect.origin.y + fixPadding)/fixHeight,
                                     y: cropRect.origin.x/size.width,
                                     width: cropRect.size.height/fixHeight,
                                     height: cropRect.size.width/size.width)
-            
-            
+
         } else {
-            let fixWidth = size.height * 1080.0 / 1920.0;
-            let fixPadding = (fixWidth - size.width)/2;
+            let fixWidth = size.height * 1080.0 / 1920.0
+            let fixPadding = (fixWidth - size.width)/2
             rectOfInterest = CGRect(x: cropRect.origin.y/size.height,
                                     y: (cropRect.origin.x + fixPadding)/fixWidth,
                                     width: cropRect.size.height/size.height,
@@ -402,46 +367,41 @@ open class LBXScanView: UIView
         }
         return rectOfInterest
     }
-    
-    func getRetangeSize()->CGSize
-    {
+
+    func getRetangeSize() -> CGSize {
         let XRetangleLeft = viewStyle.xScanRetangleOffset
-        
+
         var sizeRetangle = CGSize(width: self.frame.size.width - XRetangleLeft*2, height: self.frame.size.width - XRetangleLeft*2)
-        
-        let w = sizeRetangle.width;
-        var h = w / viewStyle.whRatio;
-        
-        
-        let hInt:Int = Int(h)
+
+        let w = sizeRetangle.width
+        var h = w / viewStyle.whRatio
+
+        let hInt: Int = Int(h)
         h = CGFloat(hInt)
-        
-        sizeRetangle = CGSize(width: w, height:  h)
-        
+
+        sizeRetangle = CGSize(width: w, height: h)
+
         return sizeRetangle
     }
-    
-    func deviceStartReadying(readyStr:String)
-    {
+
+    func deviceStartReadying(readyStr: String) {
         let XRetangleLeft = viewStyle.xScanRetangleOffset
-        
+
         let sizeRetangle = getRetangeSize()
-        
+
         //扫码区域Y轴最小坐标
         let YMinRetangle = self.frame.size.height / 2.0 - sizeRetangle.height/2.0 - viewStyle.centerUpOffset
-        
+
         //设备启动状态提示
-        if (activityView == nil)
-        {
+        if (activityView == nil) {
             self.activityView = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
-            
+
             activityView?.center = CGPoint(x: XRetangleLeft +  sizeRetangle.width/2 - 50, y: YMinRetangle + sizeRetangle.height/2)
             activityView?.activityIndicatorViewStyle = UIActivityIndicatorViewStyle.whiteLarge
-            
+
             addSubview(activityView!)
-            
-            
-            let labelReadyRect = CGRect(x: activityView!.frame.origin.x + activityView!.frame.size.width + 10, y: activityView!.frame.origin.y, width: 100, height: 30);
+
+            let labelReadyRect = CGRect(x: activityView!.frame.origin.x + activityView!.frame.size.width + 10, y: activityView!.frame.origin.y, width: 100, height: 30)
             //print("%@",NSStringFromCGRect(labelReadyRect))
             self.labelReadying = UILabel(frame: labelReadyRect)
             labelReadying?.text = readyStr
@@ -450,23 +410,21 @@ open class LBXScanView: UIView
             labelReadying?.font = UIFont.systemFont(ofSize: 18.0)
             addSubview(labelReadying!)
         }
-        
-         addSubview(labelReadying!)
-         activityView?.startAnimating()
-        
+
+        addSubview(labelReadying!)
+        activityView?.startAnimating()
+
     }
-    
-    func deviceStopReadying()
-    {
-        if activityView != nil
-        {
+
+    func deviceStopReadying() {
+        if activityView != nil {
             activityView?.stopAnimating()
             activityView?.removeFromSuperview()
             labelReadying?.removeFromSuperview()
-            
+
             activityView = nil
             labelReadying = nil
-            
+
         }
     }
 

--- a/Source/LBXScanViewController.swift
+++ b/Source/LBXScanViewController.swift
@@ -11,216 +11,187 @@ import Foundation
 import AVFoundation
 
 public protocol LBXScanViewControllerDelegate: class {
-     func scanFinished(scanResult: LBXScanResult, error: String?)
+    func scanFinished(scanResult: LBXScanResult, error: String?)
 }
 
-
 open class LBXScanViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    
- //返回扫码结果，也可以通过继承本控制器，改写该handleCodeResult方法即可
-   open weak var scanResultDelegate: LBXScanViewControllerDelegate?
-    
-   open var scanObj: LBXScanWrapper?
-    
-   open var scanStyle: LBXScanViewStyle? = LBXScanViewStyle()
-    
-   open var qRScanView: LBXScanView?
 
-    
+    //返回扫码结果，也可以通过继承本控制器，改写该handleCodeResult方法即可
+    open weak var scanResultDelegate: LBXScanViewControllerDelegate?
+
+    open var scanObj: LBXScanWrapper?
+
+    open var scanStyle: LBXScanViewStyle? = LBXScanViewStyle()
+
+    open var qRScanView: LBXScanView?
+
     //启动区域识别功能
-   open var isOpenInterestRect = false
-    
+    open var isOpenInterestRect = false
+
     //识别码的类型
-   public var arrayCodeType:[AVMetadataObject.ObjectType]?
-    
+    public var arrayCodeType: [AVMetadataObject.ObjectType]?
+
     //是否需要识别后的当前图像
-   public  var isNeedCodeImage = false
-    
+    public  var isNeedCodeImage = false
+
     //相机启动提示文字
-    public var readyString:String! = "loading"
+    public var readyString: String = "loading"
 
     override open func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
-        
-              // [self.view addSubview:_qRScanView];
         self.view.backgroundColor = UIColor.black
         self.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
     }
-    
-    open func setNeedCodeImage(needCodeImg:Bool)
-    {
-        isNeedCodeImage = needCodeImg;
+
+    open func setNeedCodeImage(needCodeImg: Bool) {
+        isNeedCodeImage = needCodeImg
     }
     //设置框内识别
-    open func setOpenInterestRect(isOpen:Bool){
+    open func setOpenInterestRect(isOpen: Bool) {
         isOpenInterestRect = isOpen
     }
- 
+
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
     }
-    
+
     override open func viewDidAppear(_ animated: Bool) {
-        
+
         super.viewDidAppear(animated)
-        
+
         drawScanView()
-       
+
         perform(#selector(LBXScanViewController.startScan), with: nil, afterDelay: 0.3)
 
     }
 
-    @objc open func startScan()
-    {
+    @objc open func startScan() {
 
-        if (scanObj == nil)
-        {
+        if (scanObj == nil) {
             var cropRect = CGRect.zero
-            if isOpenInterestRect
-            {
+            if isOpenInterestRect {
                 cropRect = LBXScanView.getScanRectWithPreView(preView: self.view, style: scanStyle! )
             }
 
             //指定识别几种码
-            if arrayCodeType == nil
-            {
+            if arrayCodeType == nil {
                 arrayCodeType = [AVMetadataObject.ObjectType.qr, AVMetadataObject.ObjectType.ean13, AVMetadataObject.ObjectType.code128]
             }
 
             scanObj = try? LBXScanWrapper(videoPreView: self.view, objType: arrayCodeType!, isCaptureImg: isNeedCodeImage, cropRect: cropRect, success: { [weak self] (arrayResult) -> Void in
 
-                if let strongSelf = self
-                {
+                if let strongSelf = self {
                     //停止扫描动画
                     strongSelf.qRScanView?.stopScanAnimation()
 
                     strongSelf.handleCodeResult(arrayResult: arrayResult)
                 }
-             })
+            })
         }
-        
+
         //结束相机等待提示
         qRScanView?.deviceStopReadying()
-        
+
         //开始扫描动画
         qRScanView?.startScanAnimation()
-        
+
         //相机运行
         scanObj?.start()
     }
-    
-    open func drawScanView()
-    {
-        if qRScanView == nil
-        {
-            qRScanView = LBXScanView(frame: self.view.frame,vstyle:scanStyle! )
+
+    open func drawScanView() {
+        if qRScanView == nil {
+            qRScanView = LBXScanView(frame: self.view.frame, vstyle: scanStyle! )
             self.view.addSubview(qRScanView!)
         }
         qRScanView?.deviceStartReadying(readyStr: readyString)
-        
+
     }
-   
-    
+
     /**
      处理扫码结果，如果是继承本控制器的，可以重写该方法,作出相应地处理，或者设置delegate作出相应处理
      */
-    open func handleCodeResult(arrayResult:[LBXScanResult])
-    {
-        if let delegate = scanResultDelegate  {
-            
+    open func handleCodeResult(arrayResult: [LBXScanResult]) {
+        if let delegate = scanResultDelegate {
+
             self.navigationController? .popViewController(animated: true)
-            let result:LBXScanResult = arrayResult[0]
-            
+            let result: LBXScanResult = arrayResult[0]
+
             delegate.scanFinished(scanResult: result, error: nil)
 
-        }else{
-            
-            for result:LBXScanResult in arrayResult
-            {
-                print("%@",result.strScanned ?? "")
+        } else {
+
+            for result: LBXScanResult in arrayResult {
+                print("%@", result.strScanned ?? "")
             }
-            
-            let result:LBXScanResult = arrayResult[0]
-            
+
+            let result: LBXScanResult = arrayResult[0]
+
             showMsg(title: result.strBarCodeType, message: result.strScanned)
         }
     }
-    
+
     override open func viewWillDisappear(_ animated: Bool) {
-        
+
         NSObject.cancelPreviousPerformRequests(withTarget: self)
-        
+
         qRScanView?.stopScanAnimation()
-        
+
         scanObj?.stop()
     }
-    
-    open func openPhotoAlbum()
-    {
+
+    open func openPhotoAlbum() {
         LBXPermissions.authorizePhotoWith { [weak self] (granted) in
-            
+
             let picker = UIImagePickerController()
-            
+
             picker.sourceType = UIImagePickerControllerSourceType.photoLibrary
-            
-            picker.delegate = self;
-            
+
+            picker.delegate = self
+
             picker.allowsEditing = true
-            
-           self?.present(picker, animated: true, completion: nil)
+
+            self?.present(picker, animated: true, completion: nil)
         }
     }
-    
-    //MARK: -----相册选择图片识别二维码 （条形码没有找到系统方法）
-    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any])
-    {
+
+    // MARK: - ----相册选择图片识别二维码 （条形码没有找到系统方法）
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String: Any]) {
         picker.dismiss(animated: true, completion: nil)
-        
-        var image:UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
-        
-        if (image == nil )
-        {
+
+        var image: UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
+
+        if (image == nil ) {
             image = info[UIImagePickerControllerOriginalImage] as? UIImage
         }
-        
-        if(image != nil)
-        {
+
+        if(image != nil) {
             let arrayResult = LBXScanWrapper.recognizeQRImage(image: image!)
-            if arrayResult.count > 0
-            {
+            if arrayResult.count > 0 {
                 handleCodeResult(arrayResult: arrayResult)
                 return
             }
         }
-      
+
         showMsg(title: nil, message: NSLocalizedString("Identify failed", comment: "Identify failed"))
     }
-    
-    func showMsg(title:String?,message:String?)
-    {
-        
-            let alertController = UIAlertController(title: nil, message:message, preferredStyle: UIAlertControllerStyle.alert)
-            let alertAction = UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: UIAlertActionStyle.default) { (alertAction) in
-                
-//                if let strongSelf = self
-//                {
-//                    strongSelf.startScan()
-//                }
-            }
-        
-            alertController.addAction(alertAction)
-            present(alertController, animated: true, completion: nil)
+
+    func showMsg(title: String?, message: String?) {
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: UIAlertControllerStyle.alert)
+        let alertAction = UIAlertAction(title: NSLocalizedString("OK", comment: "OK"), style: UIAlertActionStyle.default) { (alertAction) in
+
+            //                if let strongSelf = self
+            //                {
+            //                    strongSelf.startScan()
+            //                }
+        }
+
+        alertController.addAction(alertAction)
+        present(alertController, animated: true, completion: nil)
     }
-    deinit
-    {
-//        print("LBXScanViewController deinit")
+    deinit {
+        //        print("LBXScanViewController deinit")
     }
-    
+
 }
-
-
-
-
-

--- a/Source/LBXScanViewController.swift
+++ b/Source/LBXScanViewController.swift
@@ -69,33 +69,33 @@ open class LBXScanViewController: UIViewController, UIImagePickerControllerDeleg
         drawScanView()
        
         perform(#selector(LBXScanViewController.startScan), with: nil, afterDelay: 0.3)
-        
+
     }
-    
+
     @objc open func startScan()
     {
-   
+
         if (scanObj == nil)
         {
             var cropRect = CGRect.zero
             if isOpenInterestRect
             {
-                cropRect = LBXScanView.getScanRectWithPreView(preView: self.view, style:scanStyle! )
+                cropRect = LBXScanView.getScanRectWithPreView(preView: self.view, style: scanStyle! )
             }
-            
+
             //指定识别几种码
             if arrayCodeType == nil
             {
-                arrayCodeType = [AVMetadataObject.ObjectType.qr ,AVMetadataObject.ObjectType.ean13 ,AVMetadataObject.ObjectType.code128]
+                arrayCodeType = [AVMetadataObject.ObjectType.qr, AVMetadataObject.ObjectType.ean13, AVMetadataObject.ObjectType.code128]
             }
-            
-            scanObj = LBXScanWrapper(videoPreView: self.view,objType:arrayCodeType!, isCaptureImg: isNeedCodeImage,cropRect:cropRect, success: { [weak self] (arrayResult) -> Void in
-                
+
+            scanObj = try? LBXScanWrapper(videoPreView: self.view, objType: arrayCodeType!, isCaptureImg: isNeedCodeImage, cropRect: cropRect, success: { [weak self] (arrayResult) -> Void in
+
                 if let strongSelf = self
                 {
                     //停止扫描动画
                     strongSelf.qRScanView?.stopScanAnimation()
-                    
+
                     strongSelf.handleCodeResult(arrayResult: arrayResult)
                 }
              })

--- a/Source/LBXScanViewStyle.swift
+++ b/Source/LBXScanViewStyle.swift
@@ -9,107 +9,82 @@
 import UIKit
 
 ///扫码区域动画效果
-public enum LBXScanViewAnimationStyle
-{
-   case LineMove   //线条上下移动
-   case NetGrid//网格
-   case LineStill//线条停止在扫码区域中央
-   case None    //无动画
+public enum LBXScanViewAnimationStyle {
+    case LineMove   //线条上下移动
+    case NetGrid    //网格
+    case LineStill  //线条停止在扫码区域中央
+    case None       //无动画
 }
 
 ///扫码区域4个角位置类型
-public enum LBXScanViewPhotoframeAngleStyle
-{
+public enum LBXScanViewPhotoframeAngleStyle {
     case Inner//内嵌，一般不显示矩形框情况下
     case Outer//外嵌,包围在矩形框的4个角
     case On   //在矩形框的4个角上，覆盖
 }
 
+public struct LBXScanViewStyle {
 
-public struct LBXScanViewStyle
-{
-    
     // MARK: - -中心位置矩形框
-    
- /// 是否需要绘制扫码矩形框，默认YES
-    public var isNeedShowRetangle:Bool = true
-    
+
+    /// 是否需要绘制扫码矩形框，默认YES
+    public var isNeedShowRetangle: Bool = true
+
     /**
-    *  默认扫码区域为正方形，如果扫码区域不是正方形，设置宽高比
-    */
-    public var whRatio:CGFloat = 1.0
-    
+     *  默认扫码区域为正方形，如果扫码区域不是正方形，设置宽高比
+     */
+    public var whRatio: CGFloat = 1.0
+
     /**
-    @brief  矩形框(视频显示透明区)域向上移动偏移量，0表示扫码透明区域在当前视图中心位置，如果负值表示扫码区域下移
-    */
-    public var centerUpOffset:CGFloat = 44
-    
+     @brief  矩形框(视频显示透明区)域向上移动偏移量，0表示扫码透明区域在当前视图中心位置，如果负值表示扫码区域下移
+     */
+    public var centerUpOffset: CGFloat = 44
+
     /**
-    *  矩形框(视频显示透明区)域离界面左边及右边距离，默认60
-    */
-    public var xScanRetangleOffset:CGFloat = 60
-    
+     *  矩形框(视频显示透明区)域离界面左边及右边距离，默认60
+     */
+    public var xScanRetangleOffset: CGFloat = 60
+
     /**
-    @brief  矩形框线条颜色，默认白色
-    */
+     @brief  矩形框线条颜色，默认白色
+     */
     public var colorRetangleLine = UIColor.white
-    
-    
-    //MARK -矩形框(扫码区域)周围4个角
-    
+
+    // MARK: -矩形框(扫码区域)周围4个角
+
     /**
-    @brief  扫码区域的4个角类型
-    */
+     @brief  扫码区域的4个角类型
+     */
     public var photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Outer
-    
+
     //4个角的颜色
     public var colorAngle = UIColor(red: 0.0, green: 167.0/255.0, blue: 231.0/255.0, alpha: 1.0)
-    
+
     //扫码区域4个角的宽度和高度
-    public var photoframeAngleW:CGFloat = 24.0
-    public var photoframeAngleH:CGFloat = 24.0
+    public var photoframeAngleW: CGFloat = 24.0
+    public var photoframeAngleH: CGFloat = 24.0
     /**
-    @brief  扫码区域4个角的线条宽度,默认6，建议8到4之间
-    */
-    public var photoframeLineW:CGFloat = 6
-    
-    //MARK: ----动画效果
-    
+     @brief  扫码区域4个角的线条宽度,默认6，建议8到4之间
+     */
+    public var photoframeLineW: CGFloat = 6
+
+    // MARK: - ---动画效果
+
     /**
-    @brief  扫码动画效果:线条或网格
-    */
+     @brief  扫码动画效果:线条或网格
+     */
     public var anmiationStyle = LBXScanViewAnimationStyle.LineMove
-    
-    
+
     /**
-    *  动画效果的图像，如线条或网格的图像
-    */
-    public var animationImage:UIImage?
-    
-    
-    // MARK: -非识别区域颜色,默认 RGBA (0,0,0,0.5)，范围（0--1）
-    public var color_NotRecoginitonArea:UIColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.5);
-    
-    public init()
-    {
-        
+     *  动画效果的图像，如线条或网格的图像
+     */
+    public var animationImage: UIImage?
+
+    // MARK: - 非识别区域颜色,默认 RGBA (0,0,0,0.5)，范围（0--1）
+    public var color_NotRecoginitonArea: UIColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.5)
+
+    public init() {
+
     }
-    
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Source/LBXScanWrapper.swift
+++ b/Source/LBXScanWrapper.swift
@@ -9,20 +9,19 @@
 import UIKit
 import AVFoundation
 
-public struct  LBXScanResult {
-    
+public struct LBXScanResult {
+
     //码内容
-    public var strScanned:String? = ""
+    public var strScanned: String? = ""
     //扫描图像
-    public var imgScanned:UIImage?
+    public var imgScanned: UIImage?
     //码的类型
-    public var strBarCodeType:String? = ""
-    
+    public var strBarCodeType: String? = ""
+
     //码在图像中的位置
-    public var arrayCorner:[AnyObject]?
-    
-    public init(str:String?,img:UIImage?,barCodeType:String?,corner:[AnyObject]?)
-    {
+    public var arrayCorner: [AnyObject]?
+
+    public init(str: String?, img: UIImage?, barCodeType: String?, corner: [AnyObject]?) {
         self.strScanned = str
         self.imgScanned = img
         self.strBarCodeType = barCodeType
@@ -30,7 +29,9 @@ public struct  LBXScanResult {
     }
 }
 
-
+public enum ScannerError: Error {
+    case noCaptureDevice
+}
 
 open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
 
@@ -40,21 +41,21 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     var output: AVCaptureMetadataOutput
 
     let session = AVCaptureSession()
-    var previewLayer:AVCaptureVideoPreviewLayer?
-    var stillImageOutput:AVCaptureStillImageOutput?
-    
+    var previewLayer: AVCaptureVideoPreviewLayer?
+    var stillImageOutput: AVCaptureStillImageOutput?
+
     //存储返回结果
-    var arrayResult:[LBXScanResult] = [];
-    
+    var arrayResult: [LBXScanResult] = []
+
     //扫码结果返回block
-    var successBlock:([LBXScanResult]) -> Void
-    
+    var successBlock: ([LBXScanResult]) -> Void
+
     //是否需要拍照
-    var isNeedCaptureImage:Bool
-    
+    var isNeedCaptureImage: Bool
+
     //当前扫码结果是否处理
-    var isNeedScanResult:Bool = true
-    
+    var isNeedScanResult: Bool = true
+
     /**
      初始化设备
      - parameter videoPreView: 视频显示UIView
@@ -82,189 +83,152 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
 
             // Output
             output = AVCaptureMetadataOutput()
-        
             isNeedCaptureImage = isCaptureImg
-        
-        stillImageOutput = AVCaptureStillImageOutput();
+            stillImageOutput = AVCaptureStillImageOutput()
 
             super.init()
 
-        if device == nil
-        {
-            return
+            if session.canAddInput(input) {
+                session.addInput(input)
             }
-        
-        if session.canAddInput(input!)
-        {
-            session.addInput(input!)
-            }
-        if session.canAddOutput(output)
-        {
+            if session.canAddOutput(output) {
                 session.addOutput(output)
             }
-        if session.canAddOutput(stillImageOutput!)
-        {
+            if session.canAddOutput(stillImageOutput!) {
                 session.addOutput(stillImageOutput!)
             }
 
-        let outputSettings:Dictionary = [AVVideoCodecJPEG:AVVideoCodecKey]
-        stillImageOutput?.outputSettings = outputSettings
-    
-        session.sessionPreset = AVCaptureSession.Preset.high
-        
-        //参数设置
-        output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
-        
-        output.metadataObjectTypes = objType
-        
-//        output.metadataObjectTypes = [AVMetadataObjectTypeQRCode,AVMetadataObjectTypeEAN13Code, AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode128Code]
-        
-        if !cropRect.equalTo(CGRect.zero)
-        {
-            //启动相机后，直接修改该参数无效
-            output.rectOfInterest = cropRect
-        }
+            let outputSettings: Dictionary = [AVVideoCodecJPEG: AVVideoCodecKey]
+            stillImageOutput?.outputSettings = outputSettings
 
-        previewLayer = AVCaptureVideoPreviewLayer(session: session)
-        previewLayer?.videoGravity = AVLayerVideoGravity.resizeAspectFill
-        
-        var frame:CGRect = videoPreView.frame
-        frame.origin = CGPoint.zero
-        previewLayer?.frame = frame
-        
-        videoPreView.layer .insertSublayer(previewLayer!, at: 0)
-        
-        if ( device!.isFocusPointOfInterestSupported && device!.isFocusModeSupported(AVCaptureDevice.FocusMode.continuousAutoFocus) )
-        {
-            do
-            {
-                try input?.device.lockForConfiguration()
-                
-                input?.device.focusMode = AVCaptureDevice.FocusMode.continuousAutoFocus
-                
-                input?.device.unlockForConfiguration()
+            session.sessionPreset = AVCaptureSession.Preset.high
+
+            //参数设置
+            output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+
+            output.metadataObjectTypes = objType
+
+            //        output.metadataObjectTypes = [AVMetadataObjectTypeQRCode,AVMetadataObjectTypeEAN13Code, AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode128Code]
+
+            if !cropRect.equalTo(CGRect.zero) {
+                //启动相机后，直接修改该参数无效
+                output.rectOfInterest = cropRect
             }
-            catch let error as NSError {
-                print("device.lockForConfiguration(): \(error)")
-                
+
+            previewLayer = AVCaptureVideoPreviewLayer(session: session)
+            previewLayer?.videoGravity = AVLayerVideoGravity.resizeAspectFill
+
+            var frame: CGRect = videoPreView.frame
+            frame.origin = CGPoint.zero
+            previewLayer?.frame = frame
+
+            videoPreView.layer .insertSublayer(previewLayer!, at: 0)
+
+            if (device.isFocusPointOfInterestSupported && device.isFocusModeSupported(AVCaptureDevice.FocusMode.continuousAutoFocus) ) {
+                do {
+                    try input.device.lockForConfiguration()
+
+                    input.device.focusMode = AVCaptureDevice.FocusMode.continuousAutoFocus
+
+                    input.device.unlockForConfiguration()
+                } catch let error as NSError {
+                    print("device.lockForConfiguration(): \(error)")
+
+                }
             }
-        }
-        
+
     }
-    
+
     public func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         captureOutput(output, didOutputMetadataObjects: metadataObjects, from: connection)
     }
-    
-    func start()
-    {
-        if !session.isRunning
-        {
+
+    func start() {
+        if !session.isRunning {
             isNeedScanResult = true
             session.startRunning()
         }
     }
-    func stop()
-    {
-        if session.isRunning
-        {
+    func stop() {
+        if session.isRunning {
             isNeedScanResult = false
             session.stopRunning()
         }
     }
-    
+
     open func captureOutput(_ captureOutput: AVCaptureOutput!, didOutputMetadataObjects metadataObjects: [Any]!, from connection: AVCaptureConnection!) {
-        
-        if !isNeedScanResult
-        {
+
+        if !isNeedScanResult {
             //上一帧处理中
             return
         }
-        
+
         isNeedScanResult = false
-        
+
         arrayResult.removeAll()
-        
+
         //识别扫码类型
-        for current:Any in metadataObjects
-        {
-            if (current as AnyObject).isKind(of: AVMetadataMachineReadableCodeObject.self)
-            {
+        for current: Any in metadataObjects {
+            if (current as AnyObject).isKind(of: AVMetadataMachineReadableCodeObject.self) {
                 let code = current as! AVMetadataMachineReadableCodeObject
-                
+
                 //码类型
                 let codeType = code.type
-//                print("code type:%@",codeType)
+                //                print("code type:%@",codeType)
                 //码内容
                 let codeContent = code.stringValue
-//                print("code string:%@",codeContent)
-                
+                //                print("code string:%@",codeContent)
+
                 //4个字典，分别 左上角-右上角-右下角-左下角的 坐标百分百，可以使用这个比例抠出码的图像
                 // let arrayRatio = code.corners
-                
+
                 arrayResult.append(LBXScanResult(str: codeContent, img: UIImage(), barCodeType: codeType.rawValue, corner: code.corners as [AnyObject]?))
             }
         }
-        
-        if arrayResult.count > 0
-        {
-            if isNeedCaptureImage
-            {
+
+        if arrayResult.count > 0 {
+            if isNeedCaptureImage {
                 captureImage()
-            }
-            else
-            {
+            } else {
                 stop()
                 successBlock(arrayResult)
             }
-            
-        }
-        else
-        {
+
+        } else {
             isNeedScanResult = true
         }
-        
+
     }
-    
-    //MARK: ----拍照
-    open func captureImage()
-    {
-        let stillImageConnection:AVCaptureConnection? = connectionWithMediaType(mediaType: AVMediaType.video as AVMediaType, connections: (stillImageOutput?.connections)! as [AnyObject])
-        
-        
+
+    // MARK: - ---拍照
+    open func captureImage() {
+        let stillImageConnection: AVCaptureConnection? = connectionWithMediaType(mediaType: AVMediaType.video as AVMediaType, connections: (stillImageOutput?.connections)! as [AnyObject])
+
         stillImageOutput?.captureStillImageAsynchronously(from: stillImageConnection!, completionHandler: { (imageDataSampleBuffer, error) -> Void in
-            
+
             self.stop()
-            if imageDataSampleBuffer != nil
-            {
+            if imageDataSampleBuffer != nil {
                 let imageData: Data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(imageDataSampleBuffer!)!
-                let scanImg:UIImage? = UIImage(data: imageData)
-                
-                
-                for idx in 0...self.arrayResult.count-1
-                {
+                let scanImg: UIImage? = UIImage(data: imageData)
+
+                for idx in 0...self.arrayResult.count-1 {
                     self.arrayResult[idx].imgScanned = scanImg
                 }
             }
-            
+
             self.successBlock(self.arrayResult)
-            
+
         })
     }
-    
-    open func connectionWithMediaType(mediaType:AVMediaType, connections:[AnyObject]) -> AVCaptureConnection?
-    {
-        for connection:AnyObject in connections
-        {
-            let connectionTmp:AVCaptureConnection = connection as! AVCaptureConnection
-            
-            for port:Any in connectionTmp.inputPorts
-            {
-                if (port as AnyObject).isKind(of: AVCaptureInput.Port.self)
-                {
-                    let portTmp:AVCaptureInput.Port = port as! AVCaptureInput.Port
-                    if portTmp.mediaType == (mediaType)
-                    {
+
+    open func connectionWithMediaType(mediaType: AVMediaType, connections: [AnyObject]) -> AVCaptureConnection? {
+        for connection: AnyObject in connections {
+            let connectionTmp: AVCaptureConnection = connection as! AVCaptureConnection
+
+            for port: Any in connectionTmp.inputPorts {
+                if (port as AnyObject).isKind(of: AVCaptureInput.Port.self) {
+                    let portTmp: AVCaptureInput.Port = port as! AVCaptureInput.Port
+                    if portTmp.mediaType == (mediaType) {
                         return connectionTmp
                     }
                 }
@@ -272,28 +236,23 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         }
         return nil
     }
-    
-    
-    //MARK:切换识别区域
-    open func changeScanRect(cropRect:CGRect)
-    {
+
+    // MARK: 切换识别区域
+    open func changeScanRect(cropRect: CGRect) {
         //待测试，不知道是否有效
         stop()
         output.rectOfInterest = cropRect
         start()
     }
 
-    //MARK: 切换识别码的类型
-    open func changeScanType(objType:[AVMetadataObject.ObjectType])
-    {
+    // MARK: 切换识别码的类型
+    open func changeScanType(objType: [AVMetadataObject.ObjectType]) {
         //待测试中途修改是否有效
         output.metadataObjectTypes = objType
     }
-    
-    open func isGetFlash()->Bool
-    {
-        if (device != nil &&  device!.hasFlash && device!.hasTorch)
-        {
+
+    open func isGetFlash() -> Bool {
+        if (device.hasFlash && device.hasTorch) {
             return true
         }
         return false
@@ -303,77 +262,62 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
      打开或关闭闪关灯
      - parameter torch: true：打开闪关灯 false:关闭闪光灯
      */
-    open func setTorch(torch:Bool)
-    {
-        if isGetFlash()
-        {
-            do
-            {
-                try input?.device.lockForConfiguration()
-                
-                input?.device.torchMode = torch ? AVCaptureDevice.TorchMode.on : AVCaptureDevice.TorchMode.off
-                
-                input?.device.unlockForConfiguration()
-            }
-            catch let error as NSError {
+    open func setTorch(torch: Bool) {
+        if isGetFlash() {
+            do {
+                try input.device.lockForConfiguration()
+
+                input.device.torchMode = torch ? AVCaptureDevice.TorchMode.on : AVCaptureDevice.TorchMode.off
+
+                input.device.unlockForConfiguration()
+            } catch let error as NSError {
                 print("device.lockForConfiguration(): \(error)")
-                
+
             }
         }
-        
+
     }
-    
-    
+
     /**
-    ------闪光灯打开或关闭
-    */
-    open func changeTorch()
-    {
-        if isGetFlash()
-        {
-            do
-            {
-                try input?.device.lockForConfiguration()
-                
+     ------闪光灯打开或关闭
+     */
+    open func changeTorch() {
+        if isGetFlash() {
+            do {
+                try input.device.lockForConfiguration()
+
                 var torch = false
-                
-                if input?.device.torchMode == AVCaptureDevice.TorchMode.on
-                {
+
+                if input.device.torchMode == AVCaptureDevice.TorchMode.on {
                     torch = false
-                }
-                else if input?.device.torchMode == AVCaptureDevice.TorchMode.off
-                {
+                } else if input.device.torchMode == AVCaptureDevice.TorchMode.off {
                     torch = true
                 }
-                
-                input?.device.torchMode = torch ? AVCaptureDevice.TorchMode.on : AVCaptureDevice.TorchMode.off
-                
-                input?.device.unlockForConfiguration()
-            }
-            catch let error as NSError {
+
+                input.device.torchMode = torch ? AVCaptureDevice.TorchMode.on : AVCaptureDevice.TorchMode.off
+
+                input.device.unlockForConfiguration()
+            } catch let error as NSError {
                 print("device.lockForConfiguration(): \(error)")
-                
+
             }
         }
     }
-    
-    //MARK: ------获取系统默认支持的码的类型
-    static func defaultMetaDataObjectTypes() ->[AVMetadataObject.ObjectType]
-    {
-        var types:[AVMetadataObject.ObjectType] = [.qr, .upce,.code39,.code39Mod43,.ean13,.ean8,.code93, .code128, .pdf417,.aztec]
-        
+
+    // MARK: - -----获取系统默认支持的码的类型
+    static func defaultMetaDataObjectTypes() ->[AVMetadataObject.ObjectType] {
+        var types: [AVMetadataObject.ObjectType] = [.qr, .upce, .code39, .code39Mod43, .ean13, .ean8, .code93, .code128, .pdf417, .aztec]
+
         //if #available(iOS 8.0, *)
         types += [.interleaved2of5, .itf14, .dataMatrix]
         return types
     }
-    
-    
-    static func isSysIos8Later()->Bool
-    {
-//        return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_0
-        
+
+    static func isSysIos8Later() -> Bool {
+        //        return floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_0
+
         if #available(iOS 8, *) {
-            return true;
+            return true
         }
         return false
     }
@@ -385,91 +329,77 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
      
      - returns: 返回识别结果
      */
-    static open func recognizeQRImage(image:UIImage) ->[LBXScanResult]
-    {
-        var returnResult:[LBXScanResult]=[]
-        
-        if LBXScanWrapper.isSysIos8Later()
-        {
+    static open func recognizeQRImage(image: UIImage) -> [LBXScanResult] {
+        var returnResult: [LBXScanResult]=[]
+
+        if LBXScanWrapper.isSysIos8Later() {
             //if #available(iOS 8.0, *)
-            
-            let detector:CIDetector = CIDetector(ofType: CIDetectorTypeQRCode, context: nil, options: [CIDetectorAccuracy:CIDetectorAccuracyHigh])!
-            
+
+            let detector: CIDetector = CIDetector(ofType: CIDetectorTypeQRCode, context: nil, options: [CIDetectorAccuracy: CIDetectorAccuracyHigh])!
+
             let img = CIImage(cgImage: (image.cgImage)!)
-            
-            let features:[CIFeature]? = detector.features(in: img, options: [CIDetectorAccuracy:CIDetectorAccuracyHigh])
-            
-            if( features != nil && (features?.count)! > 0)
-            {
+
+            let features: [CIFeature]? = detector.features(in: img, options: [CIDetectorAccuracy: CIDetectorAccuracyHigh])
+
+            if( features != nil && (features?.count)! > 0) {
                 let feature = features![0]
-                
-                if feature.isKind(of: CIQRCodeFeature.self)
-                {
-                    let featureTmp:CIQRCodeFeature = feature as! CIQRCodeFeature
-                    
+
+                if feature.isKind(of: CIQRCodeFeature.self) {
+                    let featureTmp: CIQRCodeFeature = feature as! CIQRCodeFeature
+
                     let scanResult = featureTmp.messageString
-                    
-                    
+
                     let result = LBXScanResult(str: scanResult, img: image, barCodeType: AVMetadataObject.ObjectType.qr.rawValue, corner: nil)
-                    
+
                     returnResult.append(result)
                 }
             }
-            
+
         }
-        
+
         return returnResult
     }
 
-    
-    //MARK: -- - 生成二维码，背景色及二维码颜色设置
-    static open func createCode( codeType:String, codeString:String, size:CGSize,qrColor:UIColor,bkColor:UIColor )->UIImage?
-    {
+    // MARK: - - - 生成二维码，背景色及二维码颜色设置
+    static open func createCode( codeType: String, codeString: String, size: CGSize, qrColor: UIColor, bkColor: UIColor ) -> UIImage? {
         //if #available(iOS 8.0, *)
-        
+
         let stringData = codeString.data(using: String.Encoding.utf8)
-        
-        
+
         //系统自带能生成的码
         //        CIAztecCodeGenerator
         //        CICode128BarcodeGenerator
         //        CIPDF417BarcodeGenerator
         //        CIQRCodeGenerator
         let qrFilter = CIFilter(name: codeType)
-        
-        
+
         qrFilter?.setValue(stringData, forKey: "inputMessage")
-        
+
         qrFilter?.setValue("H", forKey: "inputCorrectionLevel")
-        
-        
+
         //上色
-        let colorFilter = CIFilter(name: "CIFalseColor", withInputParameters: ["inputImage":qrFilter!.outputImage!,"inputColor0":CIColor(cgColor: qrColor.cgColor),"inputColor1":CIColor(cgColor: bkColor.cgColor)])
-        
-        
-        let qrImage = colorFilter!.outputImage!;
-        
+        let colorFilter = CIFilter(name: "CIFalseColor", withInputParameters: ["inputImage": qrFilter!.outputImage!, "inputColor0": CIColor(cgColor: qrColor.cgColor), "inputColor1": CIColor(cgColor: bkColor.cgColor)])
+
+        let qrImage = colorFilter!.outputImage!
+
         //绘制
         let cgImage = CIContext().createCGImage(qrImage, from: qrImage.extent)!
-        
-        
-        UIGraphicsBeginImageContext(size);
-        let context = UIGraphicsGetCurrentContext()!;
-        context.interpolationQuality = CGInterpolationQuality.none;
-        context.scaleBy(x: 1.0, y: -1.0);
+
+        UIGraphicsBeginImageContext(size)
+        let context = UIGraphicsGetCurrentContext()!
+        context.interpolationQuality = CGInterpolationQuality.none
+        context.scaleBy(x: 1.0, y: -1.0)
         context.draw(cgImage, in: context.boundingBoxOfClipPath)
-        let codeImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        
-        return codeImage        
-       
+        let codeImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return codeImage
+
     }
-    
-    static open func createCode128(  codeString:String, size:CGSize,qrColor:UIColor,bkColor:UIColor )->UIImage?
-    {
+
+    static open func createCode128(  codeString: String, size: CGSize, qrColor: UIColor, bkColor: UIColor ) -> UIImage? {
         let stringData = codeString.data(using: String.Encoding.utf8)
-        
-        
+
         //系统自带能生成的码
         //        CIAztecCodeGenerator 二维码
         //        CICode128BarcodeGenerator 条形码
@@ -478,55 +408,45 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         let qrFilter = CIFilter(name: "CICode128BarcodeGenerator")
         qrFilter?.setDefaults()
         qrFilter?.setValue(stringData, forKey: "inputMessage")
-        
-        
-        
-        let outputImage:CIImage? = qrFilter?.outputImage
+
+        let outputImage: CIImage? = qrFilter?.outputImage
         let context = CIContext()
         let cgImage = context.createCGImage(outputImage!, from: outputImage!.extent)
-        
+
         let image = UIImage(cgImage: cgImage!, scale: 1.0, orientation: UIImageOrientation.up)
-        
-        
+
         // Resize without interpolating
-        let scaleRate:CGFloat = 20.0
+        let scaleRate: CGFloat = 20.0
         let resized = resizeImage(image: image, quality: CGInterpolationQuality.none, rate: scaleRate)
-        
-        return resized;
+
+        return resized
     }
-    
-    
-    //MARK:根据扫描结果，获取图像中得二维码区域图像（如果相机拍摄角度故意很倾斜，获取的图像效果很差）
-    static func getConcreteCodeImage(srcCodeImage:UIImage,codeResult:LBXScanResult)->UIImage?
-    {
-        let rect:CGRect = getConcreteCodeRectFromImage(srcCodeImage: srcCodeImage, codeResult: codeResult)
-        
-        if rect.isEmpty
-        {
+
+    // MARK: 根据扫描结果，获取图像中得二维码区域图像（如果相机拍摄角度故意很倾斜，获取的图像效果很差）
+    static func getConcreteCodeImage(srcCodeImage: UIImage, codeResult: LBXScanResult) -> UIImage? {
+        let rect: CGRect = getConcreteCodeRectFromImage(srcCodeImage: srcCodeImage, codeResult: codeResult)
+
+        if rect.isEmpty {
             return nil
         }
-        
+
         let img = imageByCroppingWithStyle(srcImg: srcCodeImage, rect: rect)
-        
-        if img != nil
-        {
+
+        if img != nil {
             let imgRotation = imageRotation(image: img!, orientation: UIImageOrientation.right)
             return imgRotation
         }
         return nil
     }
     //根据二维码的区域截取二维码区域图像
-    static open func getConcreteCodeImage(srcCodeImage:UIImage,rect:CGRect)->UIImage?
-    {
-        if rect.isEmpty
-        {
+    static open func getConcreteCodeImage(srcCodeImage: UIImage, rect: CGRect) -> UIImage? {
+        if rect.isEmpty {
             return nil
         }
-        
+
         let img = imageByCroppingWithStyle(srcImg: srcCodeImage, rect: rect)
-        
-        if img != nil
-        {
+
+        if img != nil {
             let imgRotation = imageRotation(image: img!, orientation: UIImageOrientation.right)
             return imgRotation
         }
@@ -534,157 +454,147 @@ open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     }
 
     //获取二维码的图像区域
-    static open func getConcreteCodeRectFromImage(srcCodeImage:UIImage,codeResult:LBXScanResult)->CGRect
-    {
-        if (codeResult.arrayCorner == nil || (codeResult.arrayCorner?.count)! < 4  )
-        {
+    static open func getConcreteCodeRectFromImage(srcCodeImage: UIImage, codeResult: LBXScanResult) -> CGRect {
+        if (codeResult.arrayCorner == nil || (codeResult.arrayCorner?.count)! < 4  ) {
             return CGRect.zero
         }
-        
-        let corner:[[String:Float]] = codeResult.arrayCorner  as! [[String:Float]]
-        
+
+        let corner: [[String: Float]] = codeResult.arrayCorner  as! [[String: Float]]
+
         let dicTopLeft     = corner[0]
         let dicTopRight    = corner[1]
         let dicBottomRight = corner[2]
         let dicBottomLeft  = corner[3]
-        
-        let xLeftTopRatio:Float = dicTopLeft["X"]!
-        let yLeftTopRatio:Float  = dicTopLeft["Y"]!
-        
-        let xRightTopRatio:Float = dicTopRight["X"]!
-        let yRightTopRatio:Float = dicTopRight["Y"]!
-        
-        let xBottomRightRatio:Float = dicBottomRight["X"]!
-        let yBottomRightRatio:Float = dicBottomRight["Y"]!
-        
-        let xLeftBottomRatio:Float = dicBottomLeft["X"]!
-        let yLeftBottomRatio:Float = dicBottomLeft["Y"]!
-        
+
+        let xLeftTopRatio: Float = dicTopLeft["X"]!
+        let yLeftTopRatio: Float  = dicTopLeft["Y"]!
+
+        let xRightTopRatio: Float = dicTopRight["X"]!
+        let yRightTopRatio: Float = dicTopRight["Y"]!
+
+        let xBottomRightRatio: Float = dicBottomRight["X"]!
+        let yBottomRightRatio: Float = dicBottomRight["Y"]!
+
+        let xLeftBottomRatio: Float = dicBottomLeft["X"]!
+        let yLeftBottomRatio: Float = dicBottomLeft["Y"]!
+
         //由于截图只能矩形，所以截图不规则四边形的最大外围
         let xMinLeft = CGFloat( min(xLeftTopRatio, xLeftBottomRatio) )
         let xMaxRight = CGFloat( max(xRightTopRatio, xBottomRightRatio) )
-        
+
         let yMinTop = CGFloat( min(yLeftTopRatio, yRightTopRatio) )
         let yMaxBottom = CGFloat ( max(yLeftBottomRatio, yBottomRightRatio) )
-        
+
         let imgW = srcCodeImage.size.width
         let imgH = srcCodeImage.size.height
-        
+
         //宽高反过来计算
         let rect = CGRect(x: xMinLeft * imgH, y: yMinTop*imgW, width: (xMaxRight-xMinLeft)*imgH, height: (yMaxBottom-yMinTop)*imgW)
         return rect
     }
-    
-    //MARK: ----图像处理
-    
+
+    // MARK: - ---图像处理
+
     /**
-    @brief  图像中间加logo图片
-    @param srcImg    原图像
-    @param LogoImage logo图像
-    @param logoSize  logo图像尺寸
-    @return 加Logo的图像
-    */
-    static open func addImageLogo(srcImg:UIImage,logoImg:UIImage,logoSize:CGSize )->UIImage
-    {
-        UIGraphicsBeginImageContext(srcImg.size);
+     @brief  图像中间加logo图片
+     @param srcImg    原图像
+     @param LogoImage logo图像
+     @param logoSize  logo图像尺寸
+     @return 加Logo的图像
+     */
+    static open func addImageLogo(srcImg: UIImage, logoImg: UIImage, logoSize: CGSize ) -> UIImage {
+        UIGraphicsBeginImageContext(srcImg.size)
         srcImg.draw(in: CGRect(x: 0, y: 0, width: srcImg.size.width, height: srcImg.size.height))
-        let rect = CGRect(x: srcImg.size.width/2 - logoSize.width/2, y: srcImg.size.height/2-logoSize.height/2, width:logoSize.width, height: logoSize.height);
+        let rect = CGRect(x: srcImg.size.width/2 - logoSize.width/2, y: srcImg.size.height/2-logoSize.height/2, width: logoSize.width, height: logoSize.height)
         logoImg.draw(in: rect)
-        let resultingImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        return resultingImage!;
+        let resultingImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return resultingImage!
     }
 
     //图像缩放
-    static func resizeImage(image:UIImage,quality:CGInterpolationQuality,rate:CGFloat)->UIImage?
-    {
-        var resized:UIImage?;
-        let width    = image.size.width * rate;
-        let height   = image.size.height * rate;
-        
-        UIGraphicsBeginImageContext(CGSize(width: width, height: height));
-        let context = UIGraphicsGetCurrentContext();
-        context!.interpolationQuality = quality;
+    static func resizeImage(image: UIImage, quality: CGInterpolationQuality, rate: CGFloat) -> UIImage? {
+        var resized: UIImage?
+        let width    = image.size.width * rate
+        let height   = image.size.height * rate
+
+        UIGraphicsBeginImageContext(CGSize(width: width, height: height))
+        let context = UIGraphicsGetCurrentContext()
+        context!.interpolationQuality = quality
         image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
-        
-        resized = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        
-        return resized;
+
+        resized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return resized
     }
-    
-    
+
     //图像裁剪
-    static func imageByCroppingWithStyle(srcImg:UIImage,rect:CGRect)->UIImage?
-    {
+    static func imageByCroppingWithStyle(srcImg: UIImage, rect: CGRect) -> UIImage? {
         let imageRef = srcImg.cgImage
         let imagePartRef = imageRef!.cropping(to: rect)
         let cropImage = UIImage(cgImage: imagePartRef!)
-        
+
         return cropImage
     }
     //图像旋转
-    static func imageRotation(image:UIImage,orientation:UIImageOrientation)->UIImage
-    {
-        var rotate:Double = 0.0;
-        var rect:CGRect;
-        var translateX:CGFloat = 0.0;
-        var translateY:CGFloat = 0.0;
-        var scaleX:CGFloat = 1.0;
-        var scaleY:CGFloat = 1.0;
-        
+    static func imageRotation(image: UIImage, orientation: UIImageOrientation) -> UIImage {
+        var rotate: Double = 0.0
+        var rect: CGRect
+        var translateX: CGFloat = 0.0
+        var translateY: CGFloat = 0.0
+        var scaleX: CGFloat = 1.0
+        var scaleY: CGFloat = 1.0
+
         switch (orientation) {
         case UIImageOrientation.left:
-            rotate = .pi/2;
-            rect = CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width);
-            translateX = 0;
-            translateY = -rect.size.width;
-            scaleY = rect.size.width/rect.size.height;
-            scaleX = rect.size.height/rect.size.width;
-            break;
+            rotate = .pi/2
+            rect = CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width)
+            translateX = 0
+            translateY = -rect.size.width
+            scaleY = rect.size.width/rect.size.height
+            scaleX = rect.size.height/rect.size.width
+            break
         case UIImageOrientation.right:
-            rotate = 3 * .pi/2;
-            rect = CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width);
-            translateX = -rect.size.height;
-            translateY = 0;
-            scaleY = rect.size.width/rect.size.height;
-            scaleX = rect.size.height/rect.size.width;
-            break;
+            rotate = 3 * .pi/2
+            rect = CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width)
+            translateX = -rect.size.height
+            translateY = 0
+            scaleY = rect.size.width/rect.size.height
+            scaleX = rect.size.height/rect.size.width
+            break
         case UIImageOrientation.down:
-            rotate = .pi;
-            rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height);
-            translateX = -rect.size.width;
-            translateY = -rect.size.height;
-            break;
+            rotate = .pi
+            rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+            translateX = -rect.size.width
+            translateY = -rect.size.height
+            break
         default:
-            rotate = 0.0;
-            rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height);
-            translateX = 0;
-            translateY = 0;
-            break;
+            rotate = 0.0
+            rect = CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+            translateX = 0
+            translateY = 0
+            break
         }
-        
-        UIGraphicsBeginImageContext(rect.size);
-        let context = UIGraphicsGetCurrentContext()!;
+
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()!
         //做CTM变换
-        context.translateBy(x: 0.0, y: rect.size.height);
-        context.scaleBy(x: 1.0, y: -1.0);
-        context.rotate(by: CGFloat(rotate));
-        context.translateBy(x: translateX, y: translateY);
-        
-        context.scaleBy(x: scaleX, y: scaleY);
+        context.translateBy(x: 0.0, y: rect.size.height)
+        context.scaleBy(x: 1.0, y: -1.0)
+        context.rotate(by: CGFloat(rotate))
+        context.translateBy(x: translateX, y: translateY)
+
+        context.scaleBy(x: scaleX, y: scaleY)
         //绘制图片
-        context.draw(image.cgImage!, in: CGRect(x: 0, y: 0, width: rect.size.width, height: rect.size.height))        
-        let newPic = UIGraphicsGetImageFromCurrentImageContext();
-        
-        return newPic!;
+        context.draw(image.cgImage!, in: CGRect(x: 0, y: 0, width: rect.size.width, height: rect.size.height))
+        let newPic = UIGraphicsGetImageFromCurrentImageContext()
+
+        return newPic!
     }
 
-    deinit
-    {
-//        print("LBXScanWrapper deinit")
+    deinit {
+
     }
-    
-    
 
 }

--- a/Source/LBXScanWrapper.swift
+++ b/Source/LBXScanWrapper.swift
@@ -32,13 +32,13 @@ public struct  LBXScanResult {
 
 
 
-open class LBXScanWrapper: NSObject,AVCaptureMetadataOutputObjectsDelegate {
-    
-    let device = AVCaptureDevice.default(for: AVMediaType.video)
-    
-    var input:AVCaptureDeviceInput?
-    var output:AVCaptureMetadataOutput
-    
+open class LBXScanWrapper: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+
+    let device: AVCaptureDevice
+
+    var input: AVCaptureDeviceInput
+    var output: AVCaptureMetadataOutput
+
     let session = AVCaptureSession()
     var previewLayer:AVCaptureVideoPreviewLayer?
     var stillImageOutput:AVCaptureStillImageOutput?
@@ -64,44 +64,49 @@ open class LBXScanWrapper: NSObject,AVCaptureMetadataOutputObjectsDelegate {
      - parameter success:      返回识别信息
      - returns:
      */
-    init( videoPreView:UIView,objType:[AVMetadataObject.ObjectType] = [.qr],isCaptureImg:Bool,cropRect:CGRect=CGRect.zero,success:@escaping ( ([LBXScanResult]) -> Void) )
-    {
-        do{
-            input = try AVCaptureDeviceInput(device: device!)
-        }
-        catch let error as NSError {
-            print("AVCaptureDeviceInput(): \(error)")
-        }
+    init(videoPreView: UIView, objType: [AVMetadataObject.ObjectType] = [.qr], isCaptureImg: Bool, cropRect: CGRect=CGRect.zero, success:@escaping ( ([LBXScanResult]) -> Void) )
+        throws {
+
+            guard let device = AVCaptureDevice.default(for: AVMediaType.video) else {
+                throw ScannerError.noCaptureDevice
+            }
+            self.device = device
+
+            do {
+                input = try AVCaptureDeviceInput(device: device)
+            } catch let error as NSError {
+                throw error
+            }
+
+            successBlock = success
+
+            // Output
+            output = AVCaptureMetadataOutput()
         
-        successBlock = success
-        
-        // Output
-        output = AVCaptureMetadataOutput()
-        
-        isNeedCaptureImage = isCaptureImg
+            isNeedCaptureImage = isCaptureImg
         
         stillImageOutput = AVCaptureStillImageOutput();
-        
-        super.init()
-        
+
+            super.init()
+
         if device == nil
         {
             return
-        }
+            }
         
         if session.canAddInput(input!)
         {
             session.addInput(input!)
-        }
+            }
         if session.canAddOutput(output)
         {
-            session.addOutput(output)
-        }
+                session.addOutput(output)
+            }
         if session.canAddOutput(stillImageOutput!)
         {
-            session.addOutput(stillImageOutput!)
-        }
-        
+                session.addOutput(stillImageOutput!)
+            }
+
         let outputSettings:Dictionary = [AVVideoCodecJPEG:AVVideoCodecKey]
         stillImageOutput?.outputSettings = outputSettings
     

--- a/swiftScan.xcodeproj/project.pbxproj
+++ b/swiftScan.xcodeproj/project.pbxproj
@@ -177,9 +177,9 @@
 				TargetAttributes = {
 					7D42B9AB1C05EE9A0084D045 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = KKT5X966GB;
+						DevelopmentTeam = GZPWB57A9Z;
 						LastSwiftMigration = 0820;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -353,15 +353,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = KKT5X966GB;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GZPWB57A9Z;
 				INFOPLIST_FILE = swiftScan/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yunqueyi.Doctor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "5afb03a3-32bd-412b-9db2-5fa2d3271415";
-				PROVISIONING_PROFILE_SPECIFIER = dev_pro;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -373,15 +373,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = KKT5X966GB;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GZPWB57A9Z;
 				INFOPLIST_FILE = swiftScan/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yunqueyi.Doctor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "5afb03a3-32bd-412b-9db2-5fa2d3271415";
-				PROVISIONING_PROFILE_SPECIFIER = dev_pro;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/swiftScan.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swiftScan.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swiftScan/AppDelegate.swift
+++ b/swiftScan/AppDelegate.swift
@@ -8,14 +8,12 @@
 
 import UIKit
 
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
 //        window? = UIWindow()
 //        window?.frame = UIScreen.main.bounds;
 //        
@@ -25,4 +23,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/swiftScan/MainTableViewController.swift
+++ b/swiftScan/MainTableViewController.swift
@@ -10,32 +10,32 @@ import UIKit
 import Foundation
 import AVFoundation
 
-class MainTableViewController: UITableViewController,UIImagePickerControllerDelegate,UINavigationControllerDelegate {
-    
-    var arrayItems:Array<Array<String>> = [
-    ["模拟qq扫码界面","qqStyle"],
-    ["模仿支付宝扫码区域","ZhiFuBaoStyle"],
-    ["模仿微信扫码区域","weixinStyle"],
-    ["无边框，内嵌4个角","InnerStyle"],
-    ["4个角在矩形框线上,网格动画","OnStyle"],
-    ["自定义颜色","changeColor"],
-    ["只识别框内","recoCropRect"],
-    ["改变尺寸","changeSize"],
-    ["条形码效果","notSquare"],
-    ["二维码/条形码生成","myCode"],
-    ["相册","openLocalPhotoAlbum"]
-    ];
+class MainTableViewController: UITableViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    var arrayItems: Array<Array<String>> = [
+    ["模拟qq扫码界面", "qqStyle"],
+    ["模仿支付宝扫码区域", "ZhiFuBaoStyle"],
+    ["模仿微信扫码区域", "weixinStyle"],
+    ["无边框，内嵌4个角", "InnerStyle"],
+    ["4个角在矩形框线上,网格动画", "OnStyle"],
+    ["自定义颜色", "changeColor"],
+    ["只识别框内", "recoCropRect"],
+    ["改变尺寸", "changeSize"],
+    ["条形码效果", "notSquare"],
+    ["二维码/条形码生成", "myCode"],
+    ["相册", "openLocalPhotoAlbum"]
+    ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.title = "swift 扫一扫"
-        
+
        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "reuseIdentifier")
         self.tableView.delegate = self
         self.tableView.dataSource = self
     }
-    
+
     // MARK: - Table view data source
 
      func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -48,362 +48,316 @@ class MainTableViewController: UITableViewController,UIImagePickerControllerDele
         return arrayItems.count
     }
 
-    
      func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath as IndexPath)
 
         // Configure the cell...
         cell.textLabel?.text = arrayItems[indexPath.row].first
-        
 
         return cell
     }
      func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        
+
         //objc_msgSend对应方法好像没有
         let sel = NSSelectorFromString(arrayItems[indexPath.row].last!)
-        
-        
+
         self.InnerStyle()
-        
-        
+
         tableView.deselectRow(at: indexPath as IndexPath, animated: true)
 
     }
-    
-    //MARK: ----模仿qq扫码界面---------
-    func qqStyle()
-    {
+
+    // MARK: - ---模仿qq扫码界面---------
+    func qqStyle() {
         print("qqStyle")
-        
-        let vc = QQScanViewController();
+
+        let vc = QQScanViewController()
         var style = LBXScanViewStyle()
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    //MARK: ---模仿支付宝------
-    func ZhiFuBaoStyle()
-    {
+
+    // MARK: - --模仿支付宝------
+    func ZhiFuBaoStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
-        style.centerUpOffset = 60;
-        style.xScanRetangleOffset = 30;
-        
-        if UIScreen.main.bounds.size.height <= 480
-        {
+
+        style.centerUpOffset = 60
+        style.xScanRetangleOffset = 30
+
+        if UIScreen.main.bounds.size.height <= 480 {
             //3.5inch 显示的扫码缩小
-            style.centerUpOffset = 40;
-            style.xScanRetangleOffset = 20;
+            style.centerUpOffset = 40
+            style.xScanRetangleOffset = 20
         }
-        
+
         style.color_NotRecoginitonArea = UIColor(red: 0.4, green: 0.4, blue: 0.4, alpha: 0.4)
-        
-        
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 2.0;
-        style.photoframeAngleW = 16;
-        style.photoframeAngleH = 16;
-        
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
+
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 2.0
+        style.photoframeAngleW = 16
+        style.photoframeAngleH = 16
+
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_full_net")
-        
-        
-        
-        let vc = LBXScanViewController();
-        
+
+        let vc = LBXScanViewController()
+
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
-        
+
     }
-    
-    func createImageWithColor(color:UIColor)->UIImage
-    {
-        let rect=CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0);
-        UIGraphicsBeginImageContext(rect.size);
-        let context = UIGraphicsGetCurrentContext();
-        context!.setFillColor(color.cgColor);
-        context!.fill(rect);
-        let theImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        return theImage!;
+
+    func createImageWithColor(color: UIColor) -> UIImage {
+        let rect=CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()
+        context!.setFillColor(color.cgColor)
+        context!.fill(rect)
+        let theImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return theImage!
     }
-    
-    //MARK: -------条形码扫码界面 ---------
-    func notSquare()
-    {
+
+    // MARK: - ------条形码扫码界面 ---------
+    func notSquare() {
         //设置扫码区域参数
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 4;
-        style.photoframeAngleW = 28;
-        style.photoframeAngleH = 16;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineStill;
-        
-        
+
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 4
+        style.photoframeAngleW = 28
+        style.photoframeAngleH = 16
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineStill
+
         style.animationImage = createImageWithColor(color: UIColor.red)
         //非正方形
         //设置矩形宽高比
-        style.whRatio = 4.3/2.18;
-        
+        style.whRatio = 4.3/2.18
+
         //离左边和右边距离
-        style.xScanRetangleOffset = 30;
-        
-        let vc = LBXScanViewController();
-        
+        style.xScanRetangleOffset = 30
+
+        let vc = LBXScanViewController()
+
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
 
-    
-    //MARK: ----无边框，内嵌4个角 -----
-    func InnerStyle()
-    {
+    // MARK: - ---无边框，内嵌4个角 -----
+    func InnerStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 3;
-        style.photoframeAngleW = 18;
-        style.photoframeAngleH = 18;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 3
+        style.photoframeAngleW = 18
+        style.photoframeAngleH = 18
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         //qq里面的线条图片
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-  
-    //MARK: ---无边框，内嵌4个角------
-    func weixinStyle()
-    {
+
+    // MARK: - --无边框，内嵌4个角------
+    func weixinStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 2;
-        style.photoframeAngleW = 18;
-        style.photoframeAngleH = 18;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 2
+        style.photoframeAngleW = 18
+        style.photoframeAngleH = 18
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         style.colorAngle = UIColor(red: 0.0/255, green: 200.0/255.0, blue: 20.0/255.0, alpha: 1.0)
-        
-        
+
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_Scan_weixin_Line")
-        
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
     }
-    
-    
-    //MARK: ----框内区域识别
-    func  recoCropRect()
-    {
+
+    // MARK: - ---框内区域识别
+    func  recoCropRect() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
-        
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
+
         //矩形框离左边缘及右边缘的距离
-        style.xScanRetangleOffset = 80;
-        
+        style.xScanRetangleOffset = 80
+
         //使用的支付宝里面网格图片
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net")
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
-        
-        
+
         vc.isOpenInterestRect = true
         //TODO:待设置框内识别
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-   
-    //MARK: -----4个角在矩形框线上,网格动画
-    func OnStyle()
-    {
+
+    // MARK: - ----4个角在矩形框线上,网格动画
+    func OnStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
-        
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
+
         //使用的支付宝里面网格图片
-        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net");
-        
-        let vc = LBXScanViewController();
+        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net")
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-    //MARK: -------自定义4个角及矩形框颜色
-    func changeColor()
-    {
+
+    // MARK: - ------自定义4个角及矩形框颜色
+    func changeColor() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         //使用的支付宝里面网格图片
-        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green");
-        
+        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
+
         //4个角的颜色
         style.colorAngle = UIColor(red: 65.0/255.0, green: 174.0/255.0, blue: 57.0/255.0, alpha: 1.0)
-       
+
         //矩形框颜色
         style.colorRetangleLine = UIColor(red: 247.0/255.0, green: 202.0/255.0, blue: 15.0/255.0, alpha: 1.0)
-        
+
         //非矩形框区域颜色
         style.color_NotRecoginitonArea = UIColor(red: 247.0/255.0, green: 202.0/255.0, blue: 15.0/255.0, alpha: 0.2)
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
-        
+
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-    //MARK: ------改变扫码区域位置
-    func changeSize()
-    {
+
+    // MARK: - -----改变扫码区域位置
+    func changeSize() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
-        //矩形框向上移动
-        style.centerUpOffset = 60;
-        //矩形框离左边缘及右边缘的距离
-        style.xScanRetangleOffset = 100;
-        
-        
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
-        //qq里面的线条图片
-        
-        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
-        let vc = LBXScanViewController();
-        vc.scanStyle = style
-        
-        self.navigationController?.pushViewController(vc, animated: true)
-        
-    }
-    
 
-    //MARK: -------- 相册
-    func openLocalPhotoAlbum()
-    {
+        //矩形框向上移动
+        style.centerUpOffset = 60
+        //矩形框离左边缘及右边缘的距离
+        style.xScanRetangleOffset = 100
+
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
+        //qq里面的线条图片
+
+        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
+        let vc = LBXScanViewController()
+        vc.scanStyle = style
+
+        self.navigationController?.pushViewController(vc, animated: true)
+
+    }
+
+    // MARK: - ------- 相册
+    func openLocalPhotoAlbum() {
         let picker = UIImagePickerController()
-        
+
         picker.sourceType = UIImagePickerControllerSourceType.photoLibrary
-        
-        picker.delegate = self;
-        
+
+        picker.delegate = self
+
         picker.allowsEditing = true
-        
+
         present(picker, animated: true, completion: nil)
     }
-    
-    //MARK: -----相册选择图片识别二维码 （条形码没有找到系统方法）
-    func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : AnyObject])
-    {
+
+    // MARK: - ----相册选择图片识别二维码 （条形码没有找到系统方法）
+    func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String: AnyObject]) {
         picker.dismiss(animated: true, completion: nil)
-        
-        var image:UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
-        
-        if (image == nil )
-        {
+
+        var image: UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
+
+        if (image == nil ) {
             image = info[UIImagePickerControllerOriginalImage] as? UIImage
         }
-        
-        if(image == nil)
-        {
+
+        if(image == nil) {
             return
         }
-        
-        if(image != nil)
-        {
+
+        if(image != nil) {
             let arrayResult = LBXScanWrapper.recognizeQRImage(image: image!)
-            if arrayResult.count > 0
-            {
-                let result = arrayResult[0];
-                
+            if arrayResult.count > 0 {
+                let result = arrayResult[0]
+
                 showMsg(title: result.strBarCodeType, message: result.strScanned)
-                
+
                 return
             }
         }
-        showMsg(title: "", message: "识别失败")       
+        showMsg(title: "", message: "识别失败")
     }
-    
-    func showMsg(title:String?,message:String?)
-    {
-        let alertController = UIAlertController(title: title, message:message, preferredStyle: UIAlertControllerStyle.alert)
-        
-        let alertAction = UIAlertAction(title:  "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
-            
-           
+
+    func showMsg(title: String?, message: String?) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)
+
+        let alertAction = UIAlertAction(title: "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
+
         }
-        
+
         alertController.addAction(alertAction)
-        
+
         present(alertController, animated: true, completion: nil)
     }
 
-    func myCode()
-    {
+    func myCode() {
         let vc = MyCodeViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/swiftScan/MyCodeViewController.swift
+++ b/swiftScan/MyCodeViewController.swift
@@ -8,18 +8,16 @@
 
 import UIKit
 
-
 class MyCodeViewController: UIViewController {
 
     //二维码
     var qrView = UIView()
     var qrImgView = UIImageView()
-    
+
     //条形码
     var tView = UIView()
     var tImgView = UIImageView()
-    
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -27,78 +25,67 @@ class MyCodeViewController: UIViewController {
         view.backgroundColor = UIColor.white
 
         drawCodeShowView()
-        
+
         createQR1()
-        
+
         createCode128()
     }
-    
- 
-    
-    //MARK: ------二维码、条形码显示位置
-    func drawCodeShowView()
-    {
+
+    // MARK: - -----二维码、条形码显示位置
+    func drawCodeShowView() {
         //二维码
-        
+
         let rect = CGRect(x: (self.view.frame.width-self.view.frame.width*5/6)/2, y: 100, width: self.view.frame.width*5/6, height: self.view.frame.width*5/6)
         qrView.frame = rect
         self.view.addSubview(qrView)
-        
+
         qrView.backgroundColor = UIColor.white
-        qrView.layer.shadowOffset = CGSize(width: 0, height: 2);
-        qrView.layer.shadowRadius = 2;
+        qrView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        qrView.layer.shadowRadius = 2
         qrView.layer.shadowColor = UIColor.black.cgColor
-        qrView.layer.shadowOpacity = 0.5;
-        
+        qrView.layer.shadowOpacity = 0.5
+
         qrImgView.bounds = CGRect(x: 0, y: 0, width: qrView.frame.width-12, height: qrView.frame.width-12)
-        qrImgView.center = CGPoint(x: qrView.frame.width/2, y: qrView.frame.height/2);
+        qrImgView.center = CGPoint(x: qrView.frame.width/2, y: qrView.frame.height/2)
         qrView .addSubview(qrImgView)
-        
-        
-        
+
         //条形码
         tView.frame = CGRect(x: (self.view.frame.width-self.view.frame.width*5/6)/2,
                              y: rect.maxY+20,
                              width: self.view.frame.width*5/6,
                              height: self.view.frame.width*5/6*0.5)
         self.view .addSubview(tView)
-        tView.layer.shadowOffset = CGSize(width: 0, height: 2);
-        tView.layer.shadowRadius = 2;
+        tView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        tView.layer.shadowRadius = 2
         tView.layer.shadowColor = UIColor.black.cgColor
-        tView.layer.shadowOpacity = 0.5;
-        
-        
-        tImgView.bounds = CGRect(x: 0, y: 0, width: tView.frame.width-12, height: tView.frame.height-12);
-        tImgView.center = CGPoint(x: tView.frame.width/2, y: tView.frame.height/2);
+        tView.layer.shadowOpacity = 0.5
+
+        tImgView.bounds = CGRect(x: 0, y: 0, width: tView.frame.width-12, height: tView.frame.height-12)
+        tImgView.center = CGPoint(x: tView.frame.width/2, y: tView.frame.height/2)
         tView .addSubview(tImgView)
-        
+
     }
-    
-    func createQR1()
-    {
+
+    func createQR1() {
        // qrView.hidden = false
        // tView.hidden = true
-        
-        let qrImg = LBXScanWrapper.createCode(codeType: "CIQRCodeGenerator",codeString:"lbxia20091227@foxmail.com", size: qrImgView.bounds.size, qrColor: UIColor.black, bkColor: UIColor.white)
-        
+
+        let qrImg = LBXScanWrapper.createCode(codeType: "CIQRCodeGenerator", codeString: "lbxia20091227@foxmail.com", size: qrImgView.bounds.size, qrColor: UIColor.black, bkColor: UIColor.white)
+
         let logoImg = UIImage(named: "logo.JPG")
         qrImgView.image = LBXScanWrapper.addImageLogo(srcImg: qrImg!, logoImg: logoImg!, logoSize: CGSize(width: 30, height: 30))
     }
-    
-    func createCode128()
-    {
-        
+
+    func createCode128() {
+
         let qrImg = LBXScanWrapper.createCode128(codeString: "005103906002", size: qrImgView.bounds.size, qrColor: UIColor.black, bkColor: UIColor.white)
-        
-       
+
         tImgView.image = qrImg
 
     }
 
-    deinit
-    {
+    deinit {
         print("MyCodeViewController deinit")
     }
-   
 
 }

--- a/swiftScan/QQScanViewController.swift
+++ b/swiftScan/QQScanViewController.swift
@@ -9,159 +9,139 @@
 import UIKit
 
 class QQScanViewController: LBXScanViewController {
-    
-    
+
     /**
     @brief  扫码区域上方提示文字
     */
-    var topTitle:UILabel?
+    var topTitle: UILabel?
 
     /**
      @brief  闪关灯开启状态
      */
-    var isOpenedFlash:Bool = false
-    
-// MARK: - 底部几个功能：开启闪光灯、相册、我的二维码
-    
-    //底部显示的功能项
-    var bottomItemsView:UIView?
-    
-    //相册
-    var btnPhoto:UIButton = UIButton()
-    
-    //闪光灯
-    var btnFlash:UIButton = UIButton()
-    
-    //我的二维码
-    var btnMyQR:UIButton = UIButton()
+    var isOpenedFlash: Bool = false
 
+// MARK: - 底部几个功能：开启闪光灯、相册、我的二维码
+
+    //底部显示的功能项
+    var bottomItemsView: UIView?
+
+    //相册
+    var btnPhoto: UIButton = UIButton()
+
+    //闪光灯
+    var btnFlash: UIButton = UIButton()
+
+    //我的二维码
+    var btnMyQR: UIButton = UIButton()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         //需要识别后的图像
         setNeedCodeImage(needCodeImg: true)
-        
+
         //框向上移动10个像素
         scanStyle?.centerUpOffset += 10
- 
+
         // Do any additional setup after loading the view.
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
-        
+
         super.viewDidAppear(animated)
-        
+
         drawBottomItems()
     }
-    
-    
-  
+
     override func handleCodeResult(arrayResult: [LBXScanResult]) {
-        
-        for result:LBXScanResult in arrayResult
-        {
+
+        for result: LBXScanResult in arrayResult {
             if let str = result.strScanned {
                 print(str)
             }
         }
-        
-        let result:LBXScanResult = arrayResult[0]
-        
+
+        let result: LBXScanResult = arrayResult[0]
+
         let vc = ScanResultController()
         vc.codeResult = result
         navigationController?.pushViewController(vc, animated: true)
     }
-    
-    func drawBottomItems()
-    {
+
+    func drawBottomItems() {
         if (bottomItemsView != nil) {
-            
-            return;
+
+            return
         }
-        
+
         let yMax = self.view.frame.maxY - self.view.frame.minY
-        
-        bottomItemsView = UIView(frame:CGRect(x: 0.0, y: yMax-100,width: self.view.frame.size.width, height: 100 ) )
-        
-        
+
+        bottomItemsView = UIView(frame: CGRect(x: 0.0, y: yMax-100, width: self.view.frame.size.width, height: 100 ) )
+
         bottomItemsView!.backgroundColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.6)
-        
+
         self.view .addSubview(bottomItemsView!)
-        
-        
-        let size = CGSize(width: 65, height: 87);
-        
+
+        let size = CGSize(width: 65, height: 87)
+
         self.btnFlash = UIButton()
         btnFlash.bounds = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         btnFlash.center = CGPoint(x: bottomItemsView!.frame.width/2, y: bottomItemsView!.frame.height/2)
-        btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_nor"), for:UIControlState.normal)
+        btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_nor"), for: UIControlState.normal)
         btnFlash.addTarget(self, action: #selector(QQScanViewController.openOrCloseFlash), for: UIControlEvents.touchUpInside)
-        
-        
+
         self.btnPhoto = UIButton()
         btnPhoto.bounds = btnFlash.bounds
         btnPhoto.center = CGPoint(x: bottomItemsView!.frame.width/4, y: bottomItemsView!.frame.height/2)
         btnPhoto.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_photo_nor"), for: UIControlState.normal)
         btnPhoto.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_photo_down"), for: UIControlState.highlighted)
 //        btnPhoto.addTarget(self, action: Selector(("openPhotoAlbum")), for: UIControlEvents.touchUpInside)
-        
+
         btnPhoto.addTarget(self, action: #selector(QQScanViewController.openLocalPhotoAlbum), for: UIControlEvents.touchUpInside)
-        
-        
+
         self.btnMyQR = UIButton()
-        btnMyQR.bounds = btnFlash.bounds;
-        btnMyQR.center = CGPoint(x: bottomItemsView!.frame.width * 3/4, y: bottomItemsView!.frame.height/2);
+        btnMyQR.bounds = btnFlash.bounds
+        btnMyQR.center = CGPoint(x: bottomItemsView!.frame.width * 3/4, y: bottomItemsView!.frame.height/2)
         btnMyQR.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_myqrcode_nor"), for: UIControlState.normal)
         btnMyQR.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_myqrcode_down"), for: UIControlState.highlighted)
         btnMyQR.addTarget(self, action: #selector(QQScanViewController.myCode), for: UIControlEvents.touchUpInside)
-        
+
         bottomItemsView?.addSubview(btnFlash)
         bottomItemsView?.addSubview(btnPhoto)
         bottomItemsView?.addSubview(btnMyQR)
-        
+
         self.view .addSubview(bottomItemsView!)
-        
+
     }
-    
-    @objc func openLocalPhotoAlbum()
-    {
-        let alertController = UIAlertController(title: "title", message:"使用首页功能", preferredStyle: UIAlertControllerStyle.alert)
-        
-        let alertAction = UIAlertAction(title:  "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
-            
-            
+
+    @objc func openLocalPhotoAlbum() {
+        let alertController = UIAlertController(title: "title", message: "使用首页功能", preferredStyle: UIAlertControllerStyle.alert)
+
+        let alertAction = UIAlertAction(title: "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
+
         }
-        
+
         alertController.addAction(alertAction)
-        
+
         present(alertController, animated: true, completion: nil)
     }
 
-    
     //开关闪光灯
-    @objc func openOrCloseFlash()
-    {
-        scanObj?.changeTorch();
-        
+    @objc func openOrCloseFlash() {
+        scanObj?.changeTorch()
+
         isOpenedFlash = !isOpenedFlash
-        
-        if isOpenedFlash
-        {
-            btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_down"), for:UIControlState.normal)
-        }
-        else
-        {
-            btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_nor"), for:UIControlState.normal)
+
+        if isOpenedFlash {
+            btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_down"), for: UIControlState.normal)
+        } else {
+            btnFlash.setImage(UIImage(named: "CodeScan.bundle/qrcode_scan_btn_flash_nor"), for: UIControlState.normal)
         }
     }
-    
-    @objc func myCode()
-    {
+
+    @objc func myCode() {
         let vc = MyCodeViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
 
-
 }
-

--- a/swiftScan/ScanResultController.swift
+++ b/swiftScan/ScanResultController.swift
@@ -8,86 +8,59 @@
 
 import UIKit
 
-
 class ScanResultController: UIViewController {
 
     @IBOutlet weak var codeImg: UIImageView!
     @IBOutlet weak var codeTypeLabel: UILabel!
     @IBOutlet weak var codeStringLabel: UILabel!
     @IBOutlet weak var concreteCodeImg: UIImageView!
-    
-    var codeResult:LBXScanResult?
-   
-    
+
+    var codeResult: LBXScanResult?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
-        
+
         codeTypeLabel.text = ""
         codeStringLabel.text = ""
 
         // Do any additional setup after loading the view.
     }
 
-    override func viewDidAppear(_ animated: Bool)
-    {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         codeImg.image = codeResult?.imgScanned
         codeTypeLabel.text = "码的类型:" + (codeResult?.strBarCodeType)!
         codeStringLabel.text = "码的内容:" + (codeResult?.strScanned)!
-        
-        if codeImg.image != nil
-        {
-//            var rect = LBXScanWrapper.getConcreteCodeRectFromImage(srcCodeImage: codeImg.image!, codeResult: codeResult!)
-//
-//            if !rect.isEmpty
-//            {
-//                zoomRect(rect: &rect, srcImg: codeImg.image!)
-//
-//                let img2 = LBXScanWrapper.getConcreteCodeImage(srcCodeImage: codeImg.image!, rect: rect)
-//
-//                if (img2 != nil)
-//                {
-//                    concreteCodeImg.image = img2
-//                }
-//            }
-            
+
+        if codeImg.image != nil {
+
         }
     }
-    
-    func zoomRect( rect:inout CGRect,srcImg:UIImage)
-    {
+
+    func zoomRect( rect:inout CGRect, srcImg: UIImage) {
         rect.origin.x -= 10
         rect.origin.y -= 10
         rect.size.width += 20
         rect.size.height += 20
-        
-        if rect.origin.x < 0
-        {
+
+        if rect.origin.x < 0 {
             rect.origin.x = 0
         }
-        
-        if (rect.origin.y < 0)
-        {
+
+        if (rect.origin.y < 0) {
             rect.origin.y = 0
         }
-        
-        if (rect.origin.x + rect.size.width) > srcImg.size.width
-        {
+
+        if (rect.origin.x + rect.size.width) > srcImg.size.width {
             rect.size.width = srcImg.size.width - rect.origin.x - 1
         }
-        
-        if (rect.origin.y + rect.size.height) > srcImg.size.height
-        {
+
+        if (rect.origin.y + rect.size.height) > srcImg.size.height {
             rect.size.height = srcImg.size.height - rect.origin.y - 1
         }
-        
-        
+
     }
 }
-
-
-
-

--- a/swiftScan/ViewController.swift
+++ b/swiftScan/ViewController.swift
@@ -8,24 +8,23 @@
 
 import UIKit
 
-class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource,UIImagePickerControllerDelegate,UINavigationControllerDelegate,LBXScanViewControllerDelegate {
+class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UIImagePickerControllerDelegate, UINavigationControllerDelegate, LBXScanViewControllerDelegate {
     var tableView: UITableView!
-    
-    
-    var arrayItems:Array<Array<String>> = [
-        ["模拟qq扫码界面","qqStyle"],
-        ["模仿支付宝扫码区域","ZhiFuBaoStyle"],
-        ["模仿微信扫码区域","weixinStyle"],
-        ["无边框，内嵌4个角","InnerStyle"],
-        ["4个角在矩形框线上,网格动画","OnStyle"],
-        ["自定义颜色","changeColor"],
-        ["只识别框内","recoCropRect"],
-        ["改变尺寸","changeSize"],
-        ["条形码效果","notSquare"],
-        ["二维码/条形码生成","myCode"],
-        ["相册","openLocalPhotoAlbum"]
-    ];
-    
+
+    var arrayItems: Array<Array<String>> = [
+        ["模拟qq扫码界面", "qqStyle"],
+        ["模仿支付宝扫码区域", "ZhiFuBaoStyle"],
+        ["模仿微信扫码区域", "weixinStyle"],
+        ["无边框，内嵌4个角", "InnerStyle"],
+        ["4个角在矩形框线上,网格动画", "OnStyle"],
+        ["自定义颜色", "changeColor"],
+        ["只识别框内", "recoCropRect"],
+        ["改变尺寸", "changeSize"],
+        ["条形码效果", "notSquare"],
+        ["二维码/条形码生成", "myCode"],
+        ["相册", "openLocalPhotoAlbum"]
+    ]
+
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView = UITableView(frame: CGRect(x: 0, y: 20, width: view.frame.width, height: view.frame.height))
@@ -35,429 +34,375 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "reuseIdentifier")
         view.addSubview(tableView)
     }
-    
-    
+
      func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // #warning Incomplete implementation, return the number of rows
         return arrayItems.count
     }
-    
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath as IndexPath)
         // Configure the cell...
         cell.textLabel?.text = arrayItems[indexPath.row].first
-        
-        
+
         return cell
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
+
         //objc_msgSend对应方法好像没有
-        
+
         if indexPath.row == 10 {
             openLocalPhotoAlbum()
-            return;
+            return
         }
-        
+
         LBXPermissions.authorizeCameraWith { [weak self] (granted) in
-            
-            if granted
-            {
-                if let strongSelf = self
-                {
-                    
+
+            if granted {
+                if let strongSelf = self {
+
                     switch indexPath.row {
                     case 0:
-                        strongSelf.qqStyle();
+                        strongSelf.qqStyle()
                     case 1:
-                        strongSelf.ZhiFuBaoStyle();
+                        strongSelf.ZhiFuBaoStyle()
                     case 2:
-                        strongSelf.weixinStyle();
+                        strongSelf.weixinStyle()
                     case 3:
-                        strongSelf.InnerStyle();
+                        strongSelf.InnerStyle()
                     case 4:
-                        strongSelf.OnStyle();
+                        strongSelf.OnStyle()
                     case 5:
-                        strongSelf.changeColor();
+                        strongSelf.changeColor()
                     case 6:
-                        strongSelf.recoCropRect();
+                        strongSelf.recoCropRect()
                     case 7:
-                        strongSelf.changeSize();
+                        strongSelf.changeSize()
                     case 8:
-                        strongSelf.notSquare();
+                        strongSelf.notSquare()
                     case 9:
                         strongSelf.myCode()
                     case 10:
-                        strongSelf.openLocalPhotoAlbum();
+                        strongSelf.openLocalPhotoAlbum()
                     default:
-                        break;
+                        break
                     }
                 }
-            }
-            else
-            {
+            } else {
                 LBXPermissions.jumpToSystemPrivacySetting()
             }
         }
-        
+
         tableView.deselectRow(at: indexPath as IndexPath, animated: true)
-        
+
     }
-    
-    //MARK: ----模仿qq扫码界面---------
-    func qqStyle()
-    {
+
+    // MARK: - ---模仿qq扫码界面---------
+    func qqStyle() {
         print("qqStyle")
-        
-        let vc = QQScanViewController();
+
+        let vc = QQScanViewController()
         var style = LBXScanViewStyle()
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    //MARK: ---模仿支付宝------
-    func ZhiFuBaoStyle()
-    {
+
+    // MARK: - --模仿支付宝------
+    func ZhiFuBaoStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
-        style.centerUpOffset = 60;
-        style.xScanRetangleOffset = 30;
-        
-        if UIScreen.main.bounds.size.height <= 480
-        {
+
+        style.centerUpOffset = 60
+        style.xScanRetangleOffset = 30
+
+        if UIScreen.main.bounds.size.height <= 480 {
             //3.5inch 显示的扫码缩小
-            style.centerUpOffset = 40;
-            style.xScanRetangleOffset = 20;
+            style.centerUpOffset = 40
+            style.xScanRetangleOffset = 20
         }
-    
-        
+
         style.color_NotRecoginitonArea = UIColor(red: 0.4, green: 0.4, blue: 0.4, alpha: 0.4)
-        
-        
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 2.0;
-        style.photoframeAngleW = 16;
-        style.photoframeAngleH = 16;
-        
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
+
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 2.0
+        style.photoframeAngleW = 16
+        style.photoframeAngleH = 16
+
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_full_net")
-        
-        
-        
-        let vc = LBXScanViewController();
-        
+
+        let vc = LBXScanViewController()
+
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
-        
+
     }
-    
-    func createImageWithColor(color:UIColor)->UIImage
-    {
-        let rect=CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0);
-        UIGraphicsBeginImageContext(rect.size);
-        let context = UIGraphicsGetCurrentContext();
-        context!.setFillColor(color.cgColor);
-        context!.fill(rect);
-        let theImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        return theImage!;
+
+    func createImageWithColor(color: UIColor) -> UIImage {
+        let rect=CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()
+        context!.setFillColor(color.cgColor)
+        context!.fill(rect)
+        let theImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return theImage!
     }
-    
-    //MARK: -------条形码扫码界面 ---------
-    func notSquare()
-    {
+
+    // MARK: - ------条形码扫码界面 ---------
+    func notSquare() {
         //设置扫码区域参数
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 4;
-        style.photoframeAngleW = 28;
-        style.photoframeAngleH = 16;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineStill;
-        
-        
+
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 4
+        style.photoframeAngleW = 28
+        style.photoframeAngleH = 16
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineStill
+
         style.animationImage = createImageWithColor(color: UIColor.red)
         //非正方形
         //设置矩形宽高比
-        style.whRatio = 4.3/2.18;
-        
+        style.whRatio = 4.3/2.18
+
         //离左边和右边距离
-        style.xScanRetangleOffset = 30;
-        
-        let vc = LBXScanViewController();
-        
+        style.xScanRetangleOffset = 30
+
+        let vc = LBXScanViewController()
+
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    //MARK: ----无边框，内嵌4个角 -----
-    func InnerStyle()
-    {
+
+    // MARK: - ---无边框，内嵌4个角 -----
+    func InnerStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 3;
-        style.photoframeAngleW = 18;
-        style.photoframeAngleH = 18;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 3
+        style.photoframeAngleW = 18
+        style.photoframeAngleH = 18
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         //qq里面的线条图片
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         vc.scanResultDelegate = self
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    //MARK: ---无边框，内嵌4个角------
-    func weixinStyle()
-    {
+
+    // MARK: - --无边框，内嵌4个角------
+    func weixinStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner;
-        style.photoframeLineW = 2;
-        style.photoframeAngleW = 18;
-        style.photoframeAngleH = 18;
-        style.isNeedShowRetangle = false;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.Inner
+        style.photoframeLineW = 2
+        style.photoframeAngleW = 18
+        style.photoframeAngleH = 18
+        style.isNeedShowRetangle = false
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         style.colorAngle = UIColor(red: 0.0/255, green: 200.0/255.0, blue: 20.0/255.0, alpha: 1.0)
-        
-        
+
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_Scan_weixin_Line")
-        
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         vc.scanResultDelegate = self
         self.navigationController?.pushViewController(vc, animated: true)
     }
-    
-    
-    //MARK: ----框内区域识别
-    func  recoCropRect()
-    {
+
+    // MARK: - ---框内区域识别
+    func  recoCropRect() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
-        
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
+
         //矩形框离左边缘及右边缘的距离
-        style.xScanRetangleOffset = 80;
-        
+        style.xScanRetangleOffset = 80
+
         //使用的支付宝里面网格图片
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net")
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
-        
-        
+
         vc.isOpenInterestRect = true
         //TODO:待设置框内识别
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-    
-    //MARK: -----4个角在矩形框线上,网格动画
-    func OnStyle()
-    {
+
+    // MARK: - ----4个角在矩形框线上,网格动画
+    func OnStyle() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        
-        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid;
-        
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+
+        style.anmiationStyle = LBXScanViewAnimationStyle.NetGrid
+
         //使用的支付宝里面网格图片
-        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net");
-        
-        let vc = LBXScanViewController();
+        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_part_net")
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-    //MARK: -------自定义4个角及矩形框颜色
-    func changeColor()
-    {
+
+    // MARK: - ------自定义4个角及矩形框颜色
+    func changeColor() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        style.centerUpOffset = 44;
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.centerUpOffset = 44
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         //使用的支付宝里面网格图片
-        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green");
-        
+        style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
+
         //4个角的颜色
         style.colorAngle = UIColor(red: 65.0/255.0, green: 174.0/255.0, blue: 57.0/255.0, alpha: 1.0)
-        
+
         //矩形框颜色
         style.colorRetangleLine = UIColor(red: 247.0/255.0, green: 202.0/255.0, blue: 15.0/255.0, alpha: 1.0)
-        
+
         //非矩形框区域颜色
         style.color_NotRecoginitonArea = UIColor(red: 247.0/255.0, green: 202.0/255.0, blue: 15.0/255.0, alpha: 0.2)
-        
-        let vc = LBXScanViewController();
+
+        let vc = LBXScanViewController()
         vc.scanStyle = style
         vc.readyString = "相机启动中..."
-        
+
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    
-    //MARK: ------改变扫码区域位置
-    func changeSize()
-    {
+
+    // MARK: - -----改变扫码区域位置
+    func changeSize() {
         //设置扫码区域参数
         var style = LBXScanViewStyle()
-        
+
         //矩形框向上移动
-        style.centerUpOffset = 60;
+        style.centerUpOffset = 60
         //矩形框离左边缘及右边缘的距离
-        style.xScanRetangleOffset = 100;
-        
-        
-        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On;
-        style.photoframeLineW = 6;
-        style.photoframeAngleW = 24;
-        style.photoframeAngleH = 24;
-        style.isNeedShowRetangle = true;
-        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove;
-        
+        style.xScanRetangleOffset = 100
+
+        style.photoframeAngleStyle = LBXScanViewPhotoframeAngleStyle.On
+        style.photoframeLineW = 6
+        style.photoframeAngleW = 24
+        style.photoframeAngleH = 24
+        style.isNeedShowRetangle = true
+        style.anmiationStyle = LBXScanViewAnimationStyle.LineMove
+
         //qq里面的线条图片
-        
+
         style.animationImage = UIImage(named: "CodeScan.bundle/qrcode_scan_light_green")
-        let vc = LBXScanViewController();
+        let vc = LBXScanViewController()
         vc.scanStyle = style
-        
+
         self.navigationController?.pushViewController(vc, animated: true)
-        
+
     }
-    
-    
-    //MARK: -------- 相册
-    func openLocalPhotoAlbum()
-    {
-        
+
+    // MARK: - ------- 相册
+    func openLocalPhotoAlbum() {
+
         LBXPermissions.authorizePhotoWith { [weak self] (granted) in
-            
-            if granted
-            {
-                if let strongSelf = self
-                {
+
+            if granted {
+                if let strongSelf = self {
                     let picker = UIImagePickerController()
                     picker.sourceType = UIImagePickerControllerSourceType.photoLibrary
-                    picker.delegate = self;
+                    picker.delegate = self
                     picker.allowsEditing = true
                    strongSelf.present(picker, animated: true, completion: nil)
                 }
-            }
-            else
-            {
+            } else {
                 LBXPermissions.jumpToSystemPrivacySetting()
             }
         }
     }
-    
-    //MARK: -----相册选择图片识别二维码 （条形码没有找到系统方法）
-    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any])
-    {
+
+    // MARK: - ----相册选择图片识别二维码 （条形码没有找到系统方法）
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String: Any]) {
         picker.dismiss(animated: true, completion: nil)
-        
-        var image:UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
-        
-        if (image == nil )
-        {
+
+        var image: UIImage? = info[UIImagePickerControllerEditedImage] as? UIImage
+
+        if (image == nil ) {
             image = info[UIImagePickerControllerOriginalImage] as? UIImage
         }
-        
-        if(image == nil)
-        {
+
+        if(image == nil) {
             return
         }
-        
-        if(image != nil)
-        {
+
+        if(image != nil) {
             let arrayResult = LBXScanWrapper.recognizeQRImage(image: image!)
-            if arrayResult.count > 0
-            {
-                let result = arrayResult[0];
-                
+            if arrayResult.count > 0 {
+                let result = arrayResult[0]
+
                 showMsg(title: result.strBarCodeType, message: result.strScanned)
-                
+
                 return
             }
         }
         showMsg(title: "", message: "识别失败")
     }
-    
-    func showMsg(title:String?,message:String?)
-    {
-        let alertController = UIAlertController(title: title, message:message, preferredStyle: UIAlertControllerStyle.alert)
-        
-        let alertAction = UIAlertAction(title:  "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
-            
-            
+
+    func showMsg(title: String?, message: String?) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)
+
+        let alertAction = UIAlertAction(title: "知道了", style: UIAlertActionStyle.default) { (alertAction) -> Void in
+
         }
-        
+
         alertController.addAction(alertAction)
-        
+
         present(alertController, animated: true, completion: nil)
     }
-    
-    func myCode()
-    {
+
+    func myCode() {
         let vc = MyCodeViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
-    
-    func scanFinished(scanResult: LBXScanResult, error: String?){
+
+    func scanFinished(scanResult: LBXScanResult, error: String?) {
         NSLog("scanResult:\(scanResult)")
     }
-    
+
 }


### PR DESCRIPTION
目前存在的问题：无法使用模拟器进行测试。我们在开发过程中，经常会使用模拟器通过从相册选择的方式进行扫码测试。但是在项目中初始化设备失败的时候使用了强制解包，导致在模拟器环境下初始化扫码会崩溃，所以对代码进行了一些调整。

### 修改说明
主要逻辑调整在 90d429c 中
- 调整属性定义方式，将LBXScanWrapper中的`device`和`input`修改为常量，并在初始化的时候赋值。
- 当`AVCaptureDevice.default(for: AVMediaType.video)`返回nil的时候抛出异常。
- 抛出AVCaptureDeviceInput初始化时候产生的异常。
- 使用`swiftlint`对代码进行格式化。

### 影响
- 初始化LBXScanWrapper的时候需要使用try `try? LBXScanWrapper(...)`
- 当没有摄像设备的时候不再崩溃，而是显示黑页面。