### PR TITLE
应该在子线程启动或停止

### DIFF
--- a/Source/LBXScanWrapper.swift
+++ b/Source/LBXScanWrapper.swift
@@ -150,14 +150,18 @@ open class LBXScanWrapper: NSObject,AVCaptureMetadataOutputObjectsDelegate {
     func start() {
         if !session.isRunning {
             isNeedScanResult = true
-            session.startRunning()
+            DispatchQueue.global().async {
+                self.session.startRunning()
+            }
         }
     }
     
     func stop() {
         if session.isRunning {
             isNeedScanResult = false
-            session.stopRunning()
+            DispatchQueue.global().async {
+                self.session.stopRunning()
+            }
         }
     }
     


### PR DESCRIPTION
Call this method to start the flow of data from the capture session’s inputs to its outputs. This method is synchronous and blocks until the session starts running or it fails, which it reports by posting an AVCaptureSessionRuntimeError notification.